### PR TITLE
Fix forgotten check-builder call.

### DIFF
--- a/org.strategoxt.imp.testing/trans/check-builders.str
+++ b/org.strategoxt.imp.testing/trans/check-builders.str
@@ -50,7 +50,7 @@ rules
         output := <execute-service(|input)> builder
       end
     where
-      error := <check-builder> (output, input, expected, condition)
+      error := <check-builder> (output, input, expected, condition, builder)
 
   check-refactoring(|ast, selections, messages, condition):
     (builder, arg, expected) -> error


### PR DESCRIPTION
Commit 041636615b1ba4dd3072c0a8a5b379dd467028eb introduces an error with "run to" test expectations.
The problem is that these no longer properly check for errors, as the call to check-builder was not
updated to match the new check-builder input term (with the added builder argument).

This should fix the problem with "run to" test expectations.
