### PR TITLE
SPT start symbol

### DIFF
--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/IFragmentParser.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/IFragmentParser.java
@@ -26,8 +26,10 @@ public interface IFragmentParser<P extends IParseUnit> {
      * @param dialect
      *            TODO I don't know what it does, but it's cool and needs to be added. For now just pass null if you
      *            also don't know what it does.
+     * @param config
+     *            optional configuration object to customize the parser's behavior.
      * @return the parse result.
      */
-    public P parse(IFragment fragment, ILanguageImpl fragmentLanguage, @Nullable ILanguageImpl dialect)
-        throws ParseException;
+    public P parse(IFragment fragment, ILanguageImpl fragmentLanguage, @Nullable ILanguageImpl dialect,
+        @Nullable IFragmentParserConfig config) throws ParseException;
 }

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/IFragmentParserConfig.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/IFragmentParserConfig.java
@@ -1,0 +1,12 @@
+package org.metaborg.mbt.core.run;
+
+/**
+ * A configuration object for the fragment parser.
+ * 
+ * This would allow implementations of the {@link IFragmentParser} to perform more customized actions.
+ * 
+ * We currently do not have any such generic customizations.
+ */
+public interface IFragmentParserConfig {
+
+}

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/ITestCaseRunner.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/ITestCaseRunner.java
@@ -25,9 +25,11 @@ public interface ITestCaseRunner<P extends IParseUnit, A extends IAnalyzeUnit> {
      * @param dialectUnderTest
      *            TODO: I don't know what this is, but it will be used to parse the fragment of the test case. If you
      *            also don't know what it is, just pass null.
+     * @param fragmentParseConfig
+     *            a configuration parameter for the {@link IFragmentParser} that will be used throughout the test run.
      * @return
      */
     public ITestResult<P, A> run(IProject project, ITestCase test, ILanguageImpl languageUnderTest,
-        @Nullable ILanguageImpl dialectUnderTest);
+        @Nullable ILanguageImpl dialectUnderTest, @Nullable IFragmentParserConfig fragmentParseConfig);
 
 }

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/ITestExpectationInput.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/ITestExpectationInput.java
@@ -31,4 +31,9 @@ public interface ITestExpectationInput<P extends IParseUnit, A extends IAnalyzeU
      */
     public IFragmentResult<P, A> getFragmentResult();
 
+    /**
+     * The configuration parameter to use during this test run for the parsing of fragments.
+     */
+    public IFragmentParserConfig getFragmentParserConfig();
+
 }

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/TestCaseRunner.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/TestCaseRunner.java
@@ -48,7 +48,7 @@ public abstract class TestCaseRunner<P extends IParseUnit, A extends IAnalyzeUni
      * {@link #evaluateExpectations(ITestCase, IParseUnit, IAnalyzeUnit, ILanguageImpl)}.
      */
     @Override public ITestResult<P, A> run(IProject project, ITestCase test, ILanguageImpl languageUnderTest,
-        @Nullable ILanguageImpl dialectUnderTest) {
+        @Nullable ILanguageImpl dialectUnderTest, @Nullable IFragmentParserConfig fragmentParseConfig) {
         logger.debug("About to run test case '{}' with language {}", test.getDescription(), languageUnderTest.id());
 
         List<IMessage> messages = Lists.newLinkedList();
@@ -56,7 +56,8 @@ public abstract class TestCaseRunner<P extends IParseUnit, A extends IAnalyzeUni
         // parse the fragment
         final P parseRes;
         try {
-            parseRes = fragmentParser.parse(test.getFragment(), languageUnderTest, dialectUnderTest);
+            parseRes =
+                fragmentParser.parse(test.getFragment(), languageUnderTest, dialectUnderTest, fragmentParseConfig);
         } catch(ParseException e) {
             // TODO: is this ok? or should we fail the test and gracefully return a message?
             throw new RuntimeException(e);
@@ -81,7 +82,8 @@ public abstract class TestCaseRunner<P extends IParseUnit, A extends IAnalyzeUni
         }
 
         // evaluate the test expectations
-        final ITestResult<P, A> result = evaluateExpectations(test, parseRes, analysisRes, languageUnderTest, messages);
+        final ITestResult<P, A> result =
+            evaluateExpectations(test, parseRes, analysisRes, languageUnderTest, messages, fragmentParseConfig);
 
         // close the analysis context for this test run
         if(context != null) {
@@ -95,7 +97,7 @@ public abstract class TestCaseRunner<P extends IParseUnit, A extends IAnalyzeUni
      * Evaluate the expectations of the test.
      */
     protected abstract ITestResult<P, A> evaluateExpectations(ITestCase test, P parseRes, A analysisRes,
-        ILanguageImpl languageUnderTest, List<IMessage> messages);
+        ILanguageImpl languageUnderTest, List<IMessage> messages, @Nullable IFragmentParserConfig fragmentParseConfig);
 
     /**
      * The maximum required phase for this input fragment.

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/TestExpectationInput.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/TestExpectationInput.java
@@ -10,12 +10,14 @@ public class TestExpectationInput<P extends IParseUnit, A extends IAnalyzeUnit> 
     private final ITestCase test;
     private final ILanguageImpl lut;
     private final IFragmentResult<P, A> fragmentResult;
+    private final IFragmentParserConfig fragmentConfig;
 
     public TestExpectationInput(ITestCase testCase, ILanguageImpl languageUnderTest,
-        IFragmentResult<P, A> fragmentResult) {
+        IFragmentResult<P, A> fragmentResult, IFragmentParserConfig fragmentConfig) {
         this.test = testCase;
         this.lut = languageUnderTest;
         this.fragmentResult = fragmentResult;
+        this.fragmentConfig = fragmentConfig;
     }
 
     @Override public ITestCase getTestCase() {
@@ -28,5 +30,9 @@ public class TestExpectationInput<P extends IParseUnit, A extends IAnalyzeUnit> 
 
     @Override public IFragmentResult<P, A> getFragmentResult() {
         return fragmentResult;
+    }
+
+    @Override public IFragmentParserConfig getFragmentParserConfig() {
+        return fragmentConfig;
     }
 }

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/WhitespaceFragmentParser.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/run/WhitespaceFragmentParser.java
@@ -28,9 +28,18 @@ public class WhitespaceFragmentParser<I extends IInputUnit, P extends IParseUnit
         this.parseService = parseService;
     }
 
-    @Override public P parse(IFragment fragment, ILanguageImpl language, @Nullable ILanguageImpl dialect)
-        throws ParseException {
+    @Override public P parse(IFragment fragment, ILanguageImpl language, @Nullable ILanguageImpl dialect,
+        @Nullable IFragmentParserConfig config) throws ParseException {
 
+        String fragmentText = getWhitespacedFragmentText(fragment);
+
+        // now we can parse the fragment
+        I input = inputService.inputUnit(fragment.getResource(), fragmentText, language, dialect);
+
+        return parse(input);
+    }
+
+    protected String getWhitespacedFragmentText(IFragment fragment) {
         StringBuilder fragmentTextBuilder = new StringBuilder();
         for(FragmentPiece piece : fragment.getText()) {
             // add whitespace to get the character offset of this piece right
@@ -40,11 +49,10 @@ public class WhitespaceFragmentParser<I extends IInputUnit, P extends IParseUnit
             // add the actual piece of program text from the fragment
             fragmentTextBuilder.append(piece.text);
         }
-        String fragmentText = fragmentTextBuilder.toString();
+        return fragmentTextBuilder.toString();
+    }
 
-        // now we can parse the fragment
-        I input = inputService.inputUnit(fragment.getResource(), fragmentText, language, dialect);
-
+    protected P parse(I input) throws ParseException {
         return parseService.parse(input);
     }
 }

--- a/org.metaborg.meta.lang.spt/syntax/spt/Common.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/Common.sdf3
@@ -4,7 +4,7 @@ lexical syntax
 
   ID             = [a-zA-Z] [a-zA-Z0-9]* 
   MODULE         = [a-zA-Z] [a-zA-Z0-9\-\_]*
-  LANG           = [a-zA-Z] [a-zA-Z0-9\-]*
+  LANG           = [a-zA-Z] [a-zA-Z0-9\-\_]*
   STRAT          = [a-zA-Z] [a-zA-Z0-9\-\']*
   INT            = "-"? [0-9]+ 
   STRING         = "\"" StringChar* "\"" 

--- a/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
@@ -5,6 +5,11 @@ imports spt/ATerm
 
 context-free start-symbols TestSuite
 
+syntax
+  TestDecl-CF.Test2 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker2-CF Fragment2-CF CloseMarker2-CF LAYOUT?-CF {Expectation "\n"}*-CF
+  TestDecl-CF.Test3 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker3-CF Fragment3-CF CloseMarker3-CF LAYOUT?-CF {Expectation "\n"}*-CF
+  TestDecl-CF.Test4 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker4-CF Fragment4-CF CloseMarker4-CF LAYOUT?-CF {Expectation "\n"}*-CF
+
 context-free syntax
   TestSuite.TestSuite = <
     <{Header "\n"}*>
@@ -15,27 +20,6 @@ context-free syntax
   // the start symbol is not supported yet by the SPT implementation
   Header.StartSymbol = <start symbol <ID>>
   Header.Language = <language <LANG>>
-
-  TestDecl.Test2 = <
-    test <Description> <OpenMarker2>
-      <Fragment2>
-    <CloseMarker2>
-    <{Expectation "\n"}*>
-  >
-  
-  TestDecl.Test3 = <
-    test <Description> <OpenMarker3>
-      <Fragment3>
-    <CloseMarker3>
-    <{Expectation "\n"}*>
-  >
-  
-  TestDecl.Test4 = <
-    test <Description> <OpenMarker4>
-      <Fragment4>
-    <CloseMarker4>
-    <{Expectation "\n"}*>
-  >
   
   // for now we only have brackets as markers
   OpenMarker2 = OpenBracket2

--- a/org.metaborg.spt.cmd/src/main/java/org/metaborg/spt/cmd/Arguments.java
+++ b/org.metaborg.spt.cmd/src/main/java/org/metaborg/spt/cmd/Arguments.java
@@ -26,4 +26,7 @@ public class Arguments {
 
     @Parameter(names = { "--exit" }, description = "Immediately exit, used for testing purposes",
         hidden = true) public boolean exit;
+
+    @Parameter(names = { "--start-symbol", "-start" }, description = "Start Symbol for these tests",
+        required = false) public String startSymbol;
 }

--- a/org.metaborg.spt.cmd/src/main/java/org/metaborg/spt/cmd/Main.java
+++ b/org.metaborg.spt.cmd/src/main/java/org/metaborg/spt/cmd/Main.java
@@ -47,7 +47,7 @@ public class Main {
             final Runner runner = injector.getInstance(Runner.class);
 
             runner.run(arguments.sptLocation, arguments.lutLocation, arguments.targetLanguageLocation,
-                arguments.testsLocation);
+                arguments.testsLocation, arguments.startSymbol);
 
             System.exit(0);
 

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTUtil.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTUtil.java
@@ -11,6 +11,7 @@ public class SPTUtil {
 
     private static final ILogger logger = LoggerUtils.logger(SPTUtil.class);
 
+    public static final String START_SYMBOL_CONS = "StartSymbol";
     public static final String TEST_CONS = "Test";
     public static final String SELECTION_CONS = "Selection";
     public static final String FRAGMENT_CONS = "Fragment";

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/ISpoofaxTestCaseExtractionResult.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/ISpoofaxTestCaseExtractionResult.java
@@ -1,13 +1,21 @@
 package org.metaborg.spt.core.extract;
 
+import javax.annotation.Nullable;
+
 import org.metaborg.mbt.core.extract.ITestCaseExtractionResult;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
 
 /**
- * Type interface for an ITestCaseExtractionResult from extracting using a Spoofax SPT language.
+ * Interface for an ITestCaseExtractionResult from extracting using a Spoofax SPT language.
+ * 
+ * Also records the start symbol of the specification.
  */
 public interface ISpoofaxTestCaseExtractionResult
     extends ITestCaseExtractionResult<ISpoofaxParseUnit, ISpoofaxAnalyzeUnit> {
 
+    /**
+     * The start symbol of the test suite specification from which you extracted.
+     */
+    public @Nullable String getStartSymbol();
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseExtractionResult.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseExtractionResult.java
@@ -9,9 +9,21 @@ import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
 public class SpoofaxTestCaseExtractionResult extends TestCaseExtractionResult<ISpoofaxParseUnit, ISpoofaxAnalyzeUnit>
     implements ISpoofaxTestCaseExtractionResult {
 
+    private final String startSymbol;
+
     public SpoofaxTestCaseExtractionResult(ISpoofaxParseUnit parseResult, ISpoofaxAnalyzeUnit analysisResult,
         Iterable<IMessage> extraMessages, Iterable<ITestCase> testCases) {
+        this(parseResult, analysisResult, extraMessages, testCases, null);
+    }
+
+    public SpoofaxTestCaseExtractionResult(ISpoofaxParseUnit parseResult, ISpoofaxAnalyzeUnit analysisResult,
+        Iterable<IMessage> extraMessages, Iterable<ITestCase> testCases, String startSymbol) {
         super(parseResult, analysisResult, extraMessages, testCases);
+        this.startSymbol = startSymbol;
+    }
+
+    @Override public String getStartSymbol() {
+        return startSymbol;
     }
 
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/FragmentUtil.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/FragmentUtil.java
@@ -19,6 +19,7 @@ import org.metaborg.core.syntax.ParseException;
 import org.metaborg.mbt.core.model.IFragment;
 import org.metaborg.mbt.core.model.ITestCase;
 import org.metaborg.mbt.core.model.expectations.MessageUtil;
+import org.metaborg.mbt.core.run.IFragmentParserConfig;
 import org.metaborg.spoofax.core.analysis.ISpoofaxAnalysisService;
 import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
@@ -109,16 +110,18 @@ public class FragmentUtil {
      *            where we collect messages.
      * @param test
      *            the test that contained the fragment.
+     * @param fragmentConfig
+     *            the config for the fragment parser.
      * 
      * @return the result of parsing the fragment. May be null if parsing failed.
      */
     public @Nullable ISpoofaxParseUnit parseFragment(IFragment fragment, String langName, Collection<IMessage> messages,
-        ITestCase test) {
+        ITestCase test, @Nullable IFragmentParserConfig fragmentConfig) {
         ILanguage lang = getLanguage(langName, messages, test);
         if(lang == null) {
             return null;
         }
-        return parseFragment(fragment, lang.activeImpl(), messages, test);
+        return parseFragment(fragment, lang.activeImpl(), messages, test, fragmentConfig);
     }
 
     /**
@@ -134,16 +137,18 @@ public class FragmentUtil {
      *            where we collect messages.
      * @param test
      *            the test that contained the fragment.
+     * @param fragmentConfig
+     *            the config for the fragment parser.
      * 
      * @return the result of parsing the fragment. May be null if parsing failed.
      */
     public @Nullable ISpoofaxParseUnit parseFragment(IFragment fragment, ILanguageImpl lang,
-        Collection<IMessage> messages, ITestCase test) {
+        Collection<IMessage> messages, ITestCase test, @Nullable IFragmentParserConfig fragmentConfig) {
         // parse the fragment
         final ISpoofaxParseUnit parsedFragment;
         try {
             // TODO: would we ever need to use a dialect?
-            parsedFragment = fragmentParser.parse(fragment, lang, null);
+            parsedFragment = fragmentParser.parse(fragment, lang, null, fragmentConfig);
         } catch(ParseException e) {
             messages.add(MessageFactory.newAnalysisError(test.getResource(), fragment.getRegion(),
                 "Unable to parse the fragment due to an exception", e));
@@ -173,12 +178,14 @@ public class FragmentUtil {
      *            where we collect messages.
      * @param test
      *            the test that contained the fragment.
+     * @param fragmentConfig
+     *            the config for the fragment parser.
      * 
      * @return the result of analyzing the fragment.
      */
     public @Nullable ISpoofaxAnalyzeUnit analyzeFragment(IFragment fragment, String langName,
-        Collection<IMessage> messages, ITestCase test) {
-        ISpoofaxParseUnit p = parseFragment(fragment, langName, messages, test);
+        Collection<IMessage> messages, ITestCase test, @Nullable IFragmentParserConfig fragmentConfig) {
+        ISpoofaxParseUnit p = parseFragment(fragment, langName, messages, test, fragmentConfig);
         if(p == null) {
             return null;
         }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/ISpoofaxFragmentParser.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/ISpoofaxFragmentParser.java
@@ -1,5 +1,8 @@
 package org.metaborg.spt.core.run;
 
+import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.core.syntax.ParseException;
+import org.metaborg.mbt.core.model.IFragment;
 import org.metaborg.mbt.core.run.IFragmentParser;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
 
@@ -8,4 +11,6 @@ import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
  */
 public interface ISpoofaxFragmentParser extends IFragmentParser<ISpoofaxParseUnit> {
 
+    ISpoofaxParseUnit parse(IFragment fragment, ILanguageImpl fragmentLanguage, ILanguageImpl dialect,
+        ISpoofaxFragmentParserConfig config) throws ParseException;
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/ISpoofaxFragmentParserConfig.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/ISpoofaxFragmentParserConfig.java
@@ -1,0 +1,19 @@
+package org.metaborg.spt.core.run;
+
+import javax.annotation.Nullable;
+
+import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.mbt.core.run.IFragmentParserConfig;
+import org.metaborg.spoofax.core.syntax.JSGLRParserConfiguration;
+
+/**
+ * Allows us to pass a parse configuration to the parser in our fragment parser.
+ */
+public interface ISpoofaxFragmentParserConfig extends IFragmentParserConfig {
+
+    public @Nullable JSGLRParserConfiguration getParserConfigForLanguage(ILanguageImpl lang);
+
+    public void putConfig(ILanguageImpl lang, JSGLRParserConfiguration config);
+
+    public void removeConfig(ILanguageImpl lang);
+}

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/ISpoofaxTestCaseRunner.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/ISpoofaxTestCaseRunner.java
@@ -3,6 +3,7 @@ package org.metaborg.spt.core.run;
 import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.core.project.IProject;
 import org.metaborg.mbt.core.model.ITestCase;
+import org.metaborg.mbt.core.run.IFragmentParserConfig;
 import org.metaborg.mbt.core.run.ITestCaseRunner;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
@@ -13,5 +14,5 @@ import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
 public interface ISpoofaxTestCaseRunner extends ITestCaseRunner<ISpoofaxParseUnit, ISpoofaxAnalyzeUnit> {
 
     @Override ISpoofaxTestResult run(IProject project, ITestCase test, ILanguageImpl languageUnderTest,
-        ILanguageImpl dialectUnderTest);
+        ILanguageImpl dialectUnderTest, IFragmentParserConfig fragmentParseConfig);
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxFragmentParserConfig.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxFragmentParserConfig.java
@@ -1,0 +1,27 @@
+package org.metaborg.spt.core.run;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.spoofax.core.syntax.JSGLRParserConfiguration;
+
+public class SpoofaxFragmentParserConfig implements ISpoofaxFragmentParserConfig {
+
+    private final Map<ILanguageImpl, JSGLRParserConfiguration> configMap = new HashMap<>();
+
+    @Override public void putConfig(ILanguageImpl lang, JSGLRParserConfiguration config) {
+        configMap.put(lang, config);
+    }
+
+    @Override public void removeConfig(ILanguageImpl lang) {
+        configMap.remove(lang);
+    }
+
+    @Override public @Nullable JSGLRParserConfiguration getParserConfigForLanguage(ILanguageImpl lang) {
+        return configMap.get(lang);
+    }
+
+}

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxTestCaseRunner.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxTestCaseRunner.java
@@ -3,6 +3,8 @@ package org.metaborg.spt.core.run;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.metaborg.core.context.IContext;
 import org.metaborg.core.context.IContextService;
 import org.metaborg.core.language.ILanguageImpl;
@@ -12,6 +14,7 @@ import org.metaborg.core.project.IProject;
 import org.metaborg.mbt.core.model.ITestCase;
 import org.metaborg.mbt.core.model.TestPhase;
 import org.metaborg.mbt.core.model.expectations.ITestExpectation;
+import org.metaborg.mbt.core.run.IFragmentParserConfig;
 import org.metaborg.mbt.core.run.ITestResult;
 import org.metaborg.mbt.core.run.TestCaseRunner;
 import org.metaborg.spoofax.core.analysis.ISpoofaxAnalysisService;
@@ -34,15 +37,16 @@ public class SpoofaxTestCaseRunner
     }
 
     @Override public ISpoofaxTestResult run(IProject project, ITestCase test, ILanguageImpl languageUnderTest,
-        ILanguageImpl dialectUnderTest) {
+        ILanguageImpl dialectUnderTest, IFragmentParserConfig fragmentParseConfig) {
         ITestResult<ISpoofaxParseUnit, ISpoofaxAnalyzeUnit> res =
-            super.run(project, test, languageUnderTest, dialectUnderTest);
+            super.run(project, test, languageUnderTest, dialectUnderTest, fragmentParseConfig);
         // safe as long as the guarantee of TestCaseRunner.run holds (see the JavaDoc of that method)
         return (ISpoofaxTestResult) res;
     }
 
     @Override protected ISpoofaxTestResult evaluateExpectations(ITestCase test, ISpoofaxParseUnit parseRes,
-        ISpoofaxAnalyzeUnit analysisRes, ILanguageImpl languageUnderTest, List<IMessage> messages) {
+        ISpoofaxAnalyzeUnit analysisRes, ILanguageImpl languageUnderTest, List<IMessage> messages,
+        @Nullable IFragmentParserConfig fragmentParseConfig) {
         boolean success = true;
 
         List<ISpoofaxTestExpectationOutput> expectationOutputs = new ArrayList<>();
@@ -60,7 +64,8 @@ public class SpoofaxTestCaseRunner
                     // an example is that we reuse it when running a transformation.
                     SpoofaxTestExpectationInput input = new SpoofaxTestExpectationInput(test, languageUnderTest,
                         new SpoofaxFragmentResult(test.getFragment(), parseRes, analysisRes,
-                            analysisRes == null ? null : analysisRes.context()));
+                            analysisRes == null ? null : analysisRes.context()),
+                        fragmentParseConfig);
                     ISpoofaxTestExpectationOutput output = evaluator.evaluate(input, expectation);
                     if(!output.isSuccessful()) {
                         success = false;

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxTestExpectationInput.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxTestExpectationInput.java
@@ -2,6 +2,7 @@ package org.metaborg.spt.core.run;
 
 import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.mbt.core.model.ITestCase;
+import org.metaborg.mbt.core.run.IFragmentParserConfig;
 import org.metaborg.mbt.core.run.TestExpectationInput;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
@@ -10,8 +11,8 @@ public class SpoofaxTestExpectationInput extends TestExpectationInput<ISpoofaxPa
     implements ISpoofaxTestExpectationInput {
 
     public SpoofaxTestExpectationInput(ITestCase testCase, ILanguageImpl languageUnderTest,
-        ISpoofaxFragmentResult fragmentResult) {
-        super(testCase, languageUnderTest, fragmentResult);
+        ISpoofaxFragmentResult fragmentResult, IFragmentParserConfig cfg) {
+        super(testCase, languageUnderTest, fragmentResult, cfg);
     }
 
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxWhitespaceFragmentParser.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxWhitespaceFragmentParser.java
@@ -1,7 +1,12 @@
 package org.metaborg.spt.core.run;
 
+import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.core.syntax.ParseException;
+import org.metaborg.mbt.core.model.IFragment;
+import org.metaborg.mbt.core.run.IFragmentParserConfig;
 import org.metaborg.mbt.core.run.WhitespaceFragmentParser;
 import org.metaborg.spoofax.core.syntax.ISpoofaxSyntaxService;
+import org.metaborg.spoofax.core.syntax.JSGLRParserConfiguration;
 import org.metaborg.spoofax.core.unit.ISpoofaxInputUnit;
 import org.metaborg.spoofax.core.unit.ISpoofaxInputUnitService;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
@@ -16,9 +21,33 @@ import com.google.inject.Inject;
 public class SpoofaxWhitespaceFragmentParser extends WhitespaceFragmentParser<ISpoofaxInputUnit, ISpoofaxParseUnit>
     implements ISpoofaxFragmentParser {
 
+    private final ISpoofaxInputUnitService inputService;
+
     @Inject public SpoofaxWhitespaceFragmentParser(ISpoofaxInputUnitService inputService,
         ISpoofaxSyntaxService parseService) {
         super(inputService, parseService);
+        this.inputService = inputService;
+    }
+
+    @Override public ISpoofaxParseUnit parse(IFragment fragment, ILanguageImpl language, ILanguageImpl dialect,
+        IFragmentParserConfig config) throws ParseException {
+        if(config == null || !(config instanceof ISpoofaxFragmentParserConfig)) {
+            return super.parse(fragment, language, dialect, config);
+        } else {
+            return parse(fragment, language, dialect, (ISpoofaxFragmentParserConfig) config);
+        }
+    }
+
+    @Override public ISpoofaxParseUnit parse(IFragment fragment, ILanguageImpl language, ILanguageImpl dialect,
+        ISpoofaxFragmentParserConfig config) throws ParseException {
+        JSGLRParserConfiguration parseConfig = config == null ? null : config.getParserConfigForLanguage(language);
+        if(parseConfig == null) {
+            return super.parse(fragment, language, dialect, config);
+        } else {
+            String text = super.getWhitespacedFragmentText(fragment);
+            ISpoofaxInputUnit input = inputService.inputUnit(text, language, dialect, parseConfig);
+            return super.parse(input);
+        }
     }
 
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ParseExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ParseExpectationEvaluator.java
@@ -90,11 +90,11 @@ public class ParseExpectationEvaluator implements ISpoofaxExpectationEvaluator<P
             if(expectation.outputLanguage() == null) {
                 // this implicitly means we parse with the LUT
                 parsedFragment = fragmentUtil.parseFragment(expectation.outputFragment(), input.getLanguageUnderTest(),
-                    messages, test);
+                    messages, test, input.getFragmentParserConfig());
             } else {
                 // parse with the given language
                 parsedFragment = fragmentUtil.parseFragment(expectation.outputFragment(), expectation.outputLanguage(),
-                    messages, test);
+                    messages, test, input.getFragmentParserConfig());
             }
             fragmentResults.add(new SpoofaxFragmentResult(expectation.outputFragment(), parsedFragment, null, null));
 

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/RunStrategoExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/RunStrategoExpectationEvaluator.java
@@ -179,7 +179,7 @@ public class RunStrategoExpectationEvaluator implements ISpoofaxExpectationEvalu
                     // it's a RunTo(strategyName, ToPart(languageName, openMarker, fragment, closeMarker))
                     // we need to analyze the fragment, at least until we support running on raw parsed terms
                     ISpoofaxAnalyzeUnit analyzedFragment = fragmentUtil.analyzeFragment(expectation.outputFragment(),
-                        expectation.outputLanguage(), messages, test);
+                        expectation.outputLanguage(), messages, test, input.getFragmentParserConfig());
                     // compare the ASTs
                     if(analyzedFragment != null
                         && TermEqualityUtil.equalsIgnoreAnnos(analyzedFragment.ast(), runtime.current(),

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/TransformExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/TransformExpectationEvaluator.java
@@ -21,6 +21,7 @@ import org.metaborg.mbt.core.model.ITestCase;
 import org.metaborg.mbt.core.model.TestPhase;
 import org.metaborg.mbt.core.model.expectations.MessageUtil;
 import org.metaborg.mbt.core.model.expectations.TransformExpectation;
+import org.metaborg.mbt.core.run.IFragmentParserConfig;
 import org.metaborg.mbt.core.run.ITestExpectationInput;
 import org.metaborg.spoofax.core.action.ActionFacet;
 import org.metaborg.spoofax.core.terms.ITermFactoryService;
@@ -128,7 +129,7 @@ public class TransformExpectationEvaluator implements ISpoofaxExpectationEvaluat
             if(result != null) {
                 // do stuff to the output fragment
                 final IStrategoTerm out = doFragment(expectation.outputFragment(), expectation.outputLanguage(), test,
-                    messages, fragmentResults, useAnalysis);
+                    messages, fragmentResults, useAnalysis, input.getFragmentParserConfig());
                 if(out != null) {
                     // check the equality
                     if(TermEqualityUtil.equalsIgnoreAnnos(result, out,
@@ -159,15 +160,16 @@ public class TransformExpectationEvaluator implements ISpoofaxExpectationEvaluat
 
     // parse or analyze the output fragment
     private @Nullable IStrategoTerm doFragment(IFragment fragment, String langName, ITestCase test,
-        Collection<IMessage> messages, List<ISpoofaxFragmentResult> fragmentResults, boolean useAnalysis) {
+        Collection<IMessage> messages, List<ISpoofaxFragmentResult> fragmentResults, boolean useAnalysis,
+        @Nullable IFragmentParserConfig fragmentConfig) {
         if(useAnalysis) {
-            ISpoofaxAnalyzeUnit a = fragmentUtil.analyzeFragment(fragment, langName, messages, test);
+            ISpoofaxAnalyzeUnit a = fragmentUtil.analyzeFragment(fragment, langName, messages, test, fragmentConfig);
             fragmentResults.add(new SpoofaxFragmentResult(fragment, a.input(), a, null));
             if(a != null && a.success() && a.hasAst()) {
                 return a.ast();
             }
         } else {
-            ISpoofaxParseUnit p = fragmentUtil.parseFragment(fragment, langName, messages, test);
+            ISpoofaxParseUnit p = fragmentUtil.parseFragment(fragment, langName, messages, test, fragmentConfig);
             fragmentResults.add(new SpoofaxFragmentResult(fragment, p, null, null));
             if(p == null || !p.valid()) {
                 messages.add(MessageFactory.newAnalysisError(test.getResource(), fragment.getRegion(),


### PR DESCRIPTION
SPT interactive now works with the `start symbol` header.
Also added some grammar fixes for comments in fragments and underscores in module- and language names.