### PR TITLE
Added fixtures and explicit references to selections

### DIFF
--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/AToPartExpectation.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/AToPartExpectation.java
@@ -22,7 +22,8 @@ public abstract class AToPartExpectation extends ATestExpectation {
         this(region, fragment, null, null);
     }
 
-    public AToPartExpectation(ISourceRegion region, IFragment fragment, String langName, ISourceRegion langNameRegion) {
+    public AToPartExpectation(ISourceRegion region, IFragment fragment, @Nullable String langName,
+        @Nullable ISourceRegion langNameRegion) {
         super(region);
         this.expectedResult = fragment;
         this.expectedResultLanguage = langName;

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/AnalysisMessageExpectation.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/AnalysisMessageExpectation.java
@@ -16,11 +16,14 @@ public class AnalysisMessageExpectation extends ATestExpectation {
 
     private final int num;
     private final MessageSeverity severity;
+    private final Iterable<Integer> selections;
 
-    public AnalysisMessageExpectation(ISourceRegion region, int num, MessageSeverity severity) {
+    public AnalysisMessageExpectation(ISourceRegion region, int num, MessageSeverity severity,
+        Iterable<Integer> selections) {
         super(region);
         this.num = num;
         this.severity = severity;
+        this.selections = selections;
     }
 
     /**
@@ -35,5 +38,14 @@ public class AnalysisMessageExpectation extends ATestExpectation {
      */
     public MessageSeverity severity() {
         return severity;
+    }
+
+    /**
+     * The references to the selections at which the messages are expected.
+     * 
+     * May be empty. May be smaller than the number of expected messages.
+     */
+    public Iterable<Integer> selections() {
+        return selections;
     }
 }

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/MessageUtil.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/MessageUtil.java
@@ -40,6 +40,30 @@ public class MessageUtil {
     }
 
     /**
+     * Create a new message with the same information, but the given message text.
+     * 
+     * @param m
+     *            the message to copy.
+     * @param msg
+     *            the message text to change to.
+     * @return the new message with the new message text.
+     */
+    public static IMessage setMessage(IMessage m, String msg) {
+        MessageBuilder b = MessageBuilder.create();
+        b.withMessage(msg);
+        b.withSeverity(m.severity());
+        b.withType(m.type());
+        b.withRegion(m.region());
+        if(m.source() != null) {
+            b.withSource(m.source());
+        }
+        if(m.exception() != null) {
+            b.withException(m.exception());
+        }
+        return b.build();
+    }
+
+    /**
      * Adds all messages in toPropagate to the given collection.
      * 
      * If any of the propagated messages does not have a region, it will be set to the given default region. This is
@@ -71,7 +95,12 @@ public class MessageUtil {
                 || region.startOffset() > bounds.endOffset()) {
                 logger.debug("Propagating '{}' at the default region due to bounds {}, not its own region {}",
                     message.message(), bounds, region);
-                messages.add(setRegion(message, defaultRegion));
+                messages
+                    .add(
+                        setMessage(setRegion(message, defaultRegion),
+                            message.message() + String.format(" (Relocated this message. Original location: (%s, %s))",
+                                region == null ? null : region.startOffset(),
+                                region == null ? null : region.endOffset())));
             } else if(region.startOffset() < bounds.startOffset() && region.endOffset() > bounds.endOffset()) {
                 logger.debug("Propagating '{}' and cutting of the beginning and end offsets", message.message());
                 messages.add(setRegion(message, new SourceRegion(bounds.startOffset(), bounds.endOffset())));

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/ParseExpectation.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/ParseExpectation.java
@@ -11,7 +11,7 @@ import org.metaborg.mbt.core.model.IFragment;
  * <ul>
  * <li>parse succeeds</li>
  * <li>parse fails</li>
- * <li>parse to [language] [fragment]</li>
+ * <li>parse to [language?] [fragment]</li>
  * </ul>
  */
 public class ParseExpectation extends AToPartExpectation {
@@ -24,7 +24,7 @@ public class ParseExpectation extends AToPartExpectation {
     }
 
     public ParseExpectation(ISourceRegion region, boolean sucessExpected, @Nullable IFragment expectedResult,
-        String expectedResultLanguage, ISourceRegion languageRegion) {
+        @Nullable String expectedResultLanguage, @Nullable ISourceRegion languageRegion) {
         super(region, expectedResult, expectedResultLanguage, languageRegion);
         this.successExpected = sucessExpected;
     }

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/RunStrategoExpectation.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/RunStrategoExpectation.java
@@ -1,5 +1,7 @@
 package org.metaborg.mbt.core.model.expectations;
 
+import javax.annotation.Nullable;
+
 import org.metaborg.core.source.ISourceRegion;
 import org.metaborg.mbt.core.model.IFragment;
 
@@ -19,7 +21,7 @@ public class RunStrategoExpectation extends AToPartExpectation {
     }
 
     public RunStrategoExpectation(ISourceRegion region, String stratName, ISourceRegion stratRegion,
-        IFragment outputFragment, String langName, ISourceRegion langRegion) {
+        IFragment outputFragment, @Nullable String langName, @Nullable ISourceRegion langRegion) {
         super(region, outputFragment, langName, langRegion);
         this.strategy = stratName;
         this.stratRegion = stratRegion;

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/RunStrategoExpectation.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/RunStrategoExpectation.java
@@ -15,16 +15,22 @@ public class RunStrategoExpectation extends AToPartExpectation {
 
     private final String strategy;
     private final ISourceRegion stratRegion;
+    @Nullable private final Integer selection;
+    @Nullable private final ISourceRegion selectionRegion;
 
-    public RunStrategoExpectation(ISourceRegion region, String stratName, ISourceRegion stratRegion) {
-        this(region, stratName, stratRegion, null, null, null);
+    public RunStrategoExpectation(ISourceRegion region, String stratName, ISourceRegion stratRegion,
+        @Nullable Integer selection, @Nullable ISourceRegion selectionRegion) {
+        this(region, stratName, stratRegion, selection, selectionRegion, null, null, null);
     }
 
     public RunStrategoExpectation(ISourceRegion region, String stratName, ISourceRegion stratRegion,
-        IFragment outputFragment, @Nullable String langName, @Nullable ISourceRegion langRegion) {
+        @Nullable Integer selection, @Nullable ISourceRegion selectionRegion, IFragment outputFragment,
+        @Nullable String langName, @Nullable ISourceRegion langRegion) {
         super(region, outputFragment, langName, langRegion);
         this.strategy = stratName;
         this.stratRegion = stratRegion;
+        this.selection = selection;
+        this.selectionRegion = selectionRegion;
     }
 
     /**
@@ -39,5 +45,25 @@ public class RunStrategoExpectation extends AToPartExpectation {
      */
     public ISourceRegion strategyRegion() {
         return stratRegion;
+    }
+
+    /**
+     * The number of the selection on which the strategy should be executed.
+     * 
+     * May be null, if it should be executed on the entire fragment.
+     */
+    public @Nullable Integer selection() {
+        return selection;
+    }
+
+    /**
+     * The region of the reference to the selection on which the strategy should be executed.
+     * 
+     * I.e. the region of the '#n' part.
+     * 
+     * May be null, iff the selection is null.
+     */
+    public @Nullable ISourceRegion selectionRegion() {
+        return selectionRegion;
     }
 }

--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/TransformExpectation.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/TransformExpectation.java
@@ -1,5 +1,7 @@
 package org.metaborg.mbt.core.model.expectations;
 
+import javax.annotation.Nullable;
+
 import org.metaborg.core.action.ITransformGoal;
 import org.metaborg.core.source.ISourceRegion;
 import org.metaborg.mbt.core.model.IFragment;
@@ -15,8 +17,8 @@ public class TransformExpectation extends AToPartExpectation {
         this(region, goal, outputFragment, null, null);
     }
 
-    public TransformExpectation(ISourceRegion region, ITransformGoal goal, IFragment outputFragment, String langName,
-        ISourceRegion langRegion) {
+    public TransformExpectation(ISourceRegion region, ITransformGoal goal, IFragment outputFragment,
+        @Nullable String langName, @Nullable ISourceRegion langRegion) {
         super(region, outputFragment, langName, langRegion);
         this.goal = goal;
     }

--- a/org.metaborg.meta.lang.spt.interactive/src/main/strategies/org/metaborg/meta/lang/spt/interactive/strategies/run_spt_core_0_0.java
+++ b/org.metaborg.meta.lang.spt.interactive/src/main/strategies/org/metaborg/meta/lang/spt/interactive/strategies/run_spt_core_0_0.java
@@ -105,7 +105,7 @@ public class run_spt_core_0_0 extends Strategy {
         String name = null;
         String lutName = null;
         String startSymbol = null;
-        if(SUITE.equals(SPTUtil.consName(baseAst)) && baseAst.getSubtermCount() == 2) {
+        if(SUITE.equals(SPTUtil.consName(baseAst)) && baseAst.getSubtermCount() == 3) {
             IStrategoTerm headers = baseAst.getSubterm(0);
             for(IStrategoTerm header : headers.getAllSubterms()) {
                 switch(SPTUtil.consName(header)) {

--- a/org.metaborg.meta.lang.spt/syntax/spt/ATerm.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/ATerm.sdf3
@@ -4,8 +4,22 @@ imports spt/Common
 
 context-free syntax
 
-ATerm.Anno = <<ATerm>{<{ATerm ", "}*>}>
-ATerm.Appl = <<ID>(<{ATerm ", "}*>)>
-ATerm.List = <[<{ATerm ", "}*>]>
-ATerm.Int = <<INT>>
-ATerm.String = <<STRING>>
+// Anno's can't be annotated again
+TermAnno.Anno = <<PreTerm>{<{PreTerm ", "}*>}>
+// Lists conflict with fragment markers, so they can't be ATerm in our grammar
+TermList.List = <[<{Term ", "}*>]>
+
+Term.Appl = <<ID>(<{MidTerm ", "}*>)>
+Term.Int = <<INT>>
+Term.String = <<STRING>>
+
+PreTerm = TermList
+PreTerm = Term
+
+MidTerm = Term
+MidTerm = TermList
+MidTerm = TermAnno
+
+ATerm = TermAnno
+ATerm = Term
+ATerm.List = <!ATerm <TermList>>

--- a/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
@@ -7,6 +7,10 @@ context-free start-symbols TestSuite
 
 syntax
   // All layout between fragment markers has to be considered part of the fragment text
+  TestFixture-CF.Fixture2 = "fixture" LAYOUT-CF OpenMarker2-CF StringPart2-CF OpenMarker2-CF LAYOUT?-CF "..." LAYOUT?-CF CloseMarker2-CF StringPart2-CF CloseMarker2-CF
+  TestFixture-CF.Fixture3 = "fixture" LAYOUT-CF OpenMarker3-CF StringPart3-CF OpenMarker3-CF LAYOUT?-CF "..." LAYOUT?-CF CloseMarker3-CF StringPart3-CF CloseMarker3-CF
+  TestFixture-CF.Fixture4 = "fixture" LAYOUT-CF OpenMarker4-CF StringPart4-CF OpenMarker4-CF LAYOUT?-CF "..." LAYOUT?-CF CloseMarker4-CF StringPart4-CF CloseMarker4-CF
+
   TestDecl-CF.Test2 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker2-CF Fragment2-CF CloseMarker2-CF LAYOUT?-CF Expectations-CF
   TestDecl-CF.Test3 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker3-CF Fragment3-CF CloseMarker3-CF LAYOUT?-CF Expectations-CF
   TestDecl-CF.Test4 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker4-CF Fragment4-CF CloseMarker4-CF LAYOUT?-CF Expectations-CF
@@ -26,6 +30,7 @@ syntax
 context-free syntax
   TestSuite.TestSuite = <
     <{Header "\n"}*>
+    <TestFixture?>
     <{TestDecl "\n\n"}*>
   >
 
@@ -51,17 +56,17 @@ context-free syntax
 
   // a term for the 'to' part that many expectations use
   ToPart.ToPart2 = <
-    to <LANG> <OpenMarker2>
+    to <LANG?> <OpenMarker2>
       <Fragment2>
     <CloseMarker2>
   >
   ToPart.ToPart3 = <
-    to <LANG> <OpenMarker3>
+    to <LANG?> <OpenMarker3>
       <Fragment3>
     <CloseMarker3>
   >
   ToPart.ToPart4 = <
-    to <LANG> <OpenMarker4>
+    to <LANG?> <OpenMarker4>
       <Fragment4>
     <CloseMarker4>
   >
@@ -117,7 +122,7 @@ lexical syntax
   StringPart2 = (~[\[\]] | OpenBracket1 | CloseBracket1)*
   StringPart3 = (~[\[] | OpenBracket1 | CloseBracket1 | OpenBracket2 | CloseBracket2)*
   StringPart4 = (~[\[] | OpenBracket1 | CloseBracket1 | OpenBracket2 | CloseBracket2 | OpenBracket3 | CloseBracket3)*
-
+  
 lexical restrictions  
   // NOTE: everything until the opening marker or newline is the description
   // update this when a new opening marker is introduced

--- a/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
@@ -102,9 +102,10 @@ context-free syntax
   Expectation.HasOrigin = <has origin locations>
   
   // running stratego strategies expectations
-  Expectation.Run = <run <STRAT>>
-  Expectation.RunTo = <run <STRAT> <ToPart>>
-  Expectation.RunToAterm = <run <STRAT> <ToAterm>>
+  OnPart.OnPart = <on #<INT>>
+  Expectation.Run = <run <STRAT> <OnPart?>>
+  Expectation.RunTo = <run <STRAT> <OnPart?> <ToPart>>
+  Expectation.RunToAterm = <run <STRAT> <OnPart?> <ToAterm>>
   
   // transformations
   Expectation.Transform = <transform <STRING> <ToPart>>

--- a/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
@@ -7,9 +7,9 @@ context-free start-symbols TestSuite
 
 syntax
   // All layout between fragment markers has to be considered part of the fragment text
-  TestDecl-CF.Test2 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker2-CF Fragment2-CF CloseMarker2-CF LAYOUT?-CF {Expectation "\n"}*-CF
-  TestDecl-CF.Test3 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker3-CF Fragment3-CF CloseMarker3-CF LAYOUT?-CF {Expectation "\n"}*-CF
-  TestDecl-CF.Test4 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker4-CF Fragment4-CF CloseMarker4-CF LAYOUT?-CF {Expectation "\n"}*-CF
+  TestDecl-CF.Test2 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker2-CF Fragment2-CF CloseMarker2-CF LAYOUT?-CF Expectations-CF
+  TestDecl-CF.Test3 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker3-CF Fragment3-CF CloseMarker3-CF LAYOUT?-CF Expectations-CF
+  TestDecl-CF.Test4 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker4-CF Fragment4-CF CloseMarker4-CF LAYOUT?-CF Expectations-CF
 
   Fragment2-CF.Fragment = StringPart2-CF TailPart2-CF
   Fragment3-CF.Fragment = StringPart3-CF TailPart3-CF
@@ -47,6 +47,7 @@ context-free syntax
   CloseMarker4 = CloseBracket4
   
   // Expectations
+  Expectations = <<{Expectation "\n"}*>>
 
   // a term for the 'to' part that many expectations use
   ToPart.ToPart2 = <

--- a/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
@@ -6,9 +6,22 @@ imports spt/ATerm
 context-free start-symbols TestSuite
 
 syntax
+  // All layout between fragment markers has to be considered part of the fragment text
   TestDecl-CF.Test2 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker2-CF Fragment2-CF CloseMarker2-CF LAYOUT?-CF {Expectation "\n"}*-CF
   TestDecl-CF.Test3 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker3-CF Fragment3-CF CloseMarker3-CF LAYOUT?-CF {Expectation "\n"}*-CF
   TestDecl-CF.Test4 = "test" LAYOUT?-CF Description-CF LAYOUT?-CF OpenMarker4-CF Fragment4-CF CloseMarker4-CF LAYOUT?-CF {Expectation "\n"}*-CF
+
+  Fragment2-CF.Fragment = StringPart2-CF TailPart2-CF
+  Fragment3-CF.Fragment = StringPart3-CF TailPart3-CF
+  Fragment4-CF.Fragment = StringPart4-CF TailPart4-CF
+  
+  TailPart2-CF.More = Selection2-CF StringPart2-CF TailPart2-CF
+  TailPart3-CF.More = Selection3-CF StringPart3-CF TailPart3-CF
+  TailPart4-CF.More = Selection4-CF StringPart4-CF TailPart4-CF
+  
+  Selection2-CF.Selection = OpenBracket2-CF StringPart2-CF CloseBracket2-CF
+  Selection3-CF.Selection = OpenBracket3-CF StringPart3-CF CloseBracket3-CF
+  Selection4-CF.Selection = OpenBracket4-CF StringPart4-CF CloseBracket4-CF
 
 context-free syntax
   TestSuite.TestSuite = <
@@ -20,7 +33,11 @@ context-free syntax
   // the start symbol is not supported yet by the SPT implementation
   Header.StartSymbol = <start symbol <ID>>
   Header.Language = <language <LANG>>
-  
+
+  TailPart2.Done = <>
+  TailPart3.Done = <>
+  TailPart4.Done = <>
+
   // for now we only have brackets as markers
   OpenMarker2 = OpenBracket2
   OpenMarker3 = OpenBracket3
@@ -28,21 +45,6 @@ context-free syntax
   CloseMarker2 = CloseBracket2
   CloseMarker3 = CloseBracket3
   CloseMarker4 = CloseBracket4
-  
-  Fragment2.Fragment = <<StringPart2><TailPart2>>
-  Fragment3.Fragment = <<StringPart3><TailPart3>>
-  Fragment4.Fragment = <<StringPart4><TailPart4>>
-  
-  TailPart2.Done = <>
-  TailPart2.More = <<Selection2><StringPart2><TailPart2>>
-  TailPart3.Done = <>
-  TailPart3.More = <<Selection3><StringPart3><TailPart3>>
-  TailPart4.Done = <>
-  TailPart4.More = <<Selection4><StringPart4><TailPart4>>
-  
-  Selection2.Selection = <<OpenBracket2><StringPart2><CloseBracket2>>
-  Selection3.Selection = <<OpenBracket3><StringPart3><CloseBracket3>>
-  Selection4.Selection = <<OpenBracket4><StringPart4><CloseBracket4>>
   
   // Expectations
 

--- a/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/SPT.sdf3
@@ -80,12 +80,19 @@ context-free syntax
   Expectation.ParseToAterm = <parse <ToAterm>>
   
   // analysis expectations
+  SelectionRef.SelectionRef = <#<INT>>
   Expectation.Errors = <<INT> errors>
+  Expectation.ErrorsAt = <<INT> errors at <{SelectionRef ", "}+>>
   Expectation.OneError = <1 error>
+  Expectation.OneErrorAt = <1 error at <SelectionRef>>
   Expectation.Warnings = <<INT> warnings>
+  Expectation.WarningsAt = <<INT> warnings at <{SelectionRef ", "}+>>
   Expectation.OneWarning = <1 warning>
+  Expectation.OneWarningAt = <1 warning at <SelectionRef>>
   Expectation.Notes = <<INT> notes>
+  Expectation.NotesAt = <<INT> notes at <{SelectionRef ", "}+>>
   Expectation.OneNote = <1 note>
+  Expectation.OneNoteAt = <1 note at <SelectionRef>>
   
   // reference resolution expectations
   Expectation.Resolve = <resolve #<INT>>

--- a/org.metaborg.meta.lang.spt/trans/spt/desugar.str
+++ b/org.metaborg.meta.lang.spt/trans/spt/desugar.str
@@ -46,7 +46,28 @@ rules
     OneWarning() -> Warnings(1)
   desugar-term-before:
     OneNote() -> Notes(1)
+  
+  // Desugar the 'n messages at ' expectations
+  desugar-term-before:
+    OneErrorAt(selref) -> ErrorsAt(1, [<desugar-selection-ref> selref])
+  desugar-term-before:
+    OneWarningAt(selref) -> WarningsAt(1, [<desugar-selection-ref> selref])
+  desugar-term-before:
+    OneNoteAt(selref) -> NotesAt(1, [<desugar-selection-ref> selref])
+  desugar-term-before:
+    ErrorsAt(n, at) -> ErrorsAt(<dec-string-to-int> n, <all(desugar-selection-ref)> at)
+  desugar-term-before:
+    WarningsAt(n, at) -> WarningsAt(<dec-string-to-int> n, <all(desugar-selection-ref)> at)
+  desugar-term-before:
+    NotesAt(n, at) -> NotesAt(<dec-string-to-int> n, <all(desugar-selection-ref)> at)
     
+    
+  // Desugar from a SelectionRef(string) to an int
+  desugar-selection-ref:
+    SelectionRef(n) -> i
+    with
+      i := <dec-string-to-int> n
+      
   // Desugar from a string to an int inside Errors|Warnings|Notes
   desugar-term-before:
     cons#([n]) -> cons#([i])
@@ -55,6 +76,7 @@ rules
       with
         i := <dec-string-to-int> n
         
+
   // Desugar from a string to an int inside Resolve|ResolveTo
   desugar-term-before:
     Resolve(n) -> Resolve(i)

--- a/org.metaborg.meta.lang.spt/trans/spt/desugar.str
+++ b/org.metaborg.meta.lang.spt/trans/spt/desugar.str
@@ -89,6 +89,13 @@ rules
       i := <dec-string-to-int> x;
       j := <dec-string-to-int> y
       
+      
+  // Desugar OnPart to int
+  desugar-term-before:
+    OnPart(n) -> i
+    with
+      i := <dec-string-to-int> n      
+      
   // Desugar our ATerms
   desugar-term-before:
     Anno(term, annos) -> term{annos}

--- a/org.metaborg.meta.lang.spt/trans/spt/desugar.str
+++ b/org.metaborg.meta.lang.spt/trans/spt/desugar.str
@@ -14,9 +14,15 @@ rules
   
   // Desugar Test
   desugar-term-before:
-    cons#([description, open_marker, fragment, close_marker, exps]) -> Test(description, open_marker, fragment, close_marker, exps)
+    cons#([description, open_marker, fragment, close_marker, exps]) -> <try(desugar-test)> Test(description, open_marker, fragment, close_marker, exps)
     where
       <eq> (cons, "Test2") + <eq> (cons, "Test3") + <eq> (cons, "Test4")
+  
+  desugar-test:
+    Test(description, open_marker, fragment, close_marker, expectations) -> Test(description, open_marker, fragment, close_marker, expectations')
+    where
+      [] := <filter(?ParseSucceeds() + ?ParseFails() + ?ParseTo(_) + ?ParseToAterm(_))> expectations;
+      expectations' := [ParseSucceeds() | expectations]
   
   // Desugar ToPart
   desugar-term-before:

--- a/org.metaborg.meta.lang.spt/trans/spt/desugar.str
+++ b/org.metaborg.meta.lang.spt/trans/spt/desugar.str
@@ -6,6 +6,8 @@ imports
 signature constructors
   // Test(description, open_marker, fragment, close_marker, expectations)
   Test : String * String * Fragment * String * List -> Test
+  // Fixture(open_marker1, str1, open_marker2, close_marker2, str2, close_marker1)
+  Fixture : String * String * String * String * String * String -> Fixture
   // ParseTo(language_name, open_marker, fragment, close_marker)
   ToPart : String * String * Fragment * String -> ParseTo
 
@@ -18,11 +20,18 @@ rules
     where
       <eq> (cons, "Test2") + <eq> (cons, "Test3") + <eq> (cons, "Test4")
   
+  // Add a parse succeeds expectation if no parse expectation is present
   desugar-test:
     Test(description, open_marker, fragment, close_marker, expectations) -> Test(description, open_marker, fragment, close_marker, expectations')
     where
       [] := <filter(?ParseSucceeds() + ?ParseFails() + ?ParseTo(_) + ?ParseToAterm(_))> expectations;
       expectations' := [ParseSucceeds() | expectations]
+  
+  // Desugar Fixture
+  desugar-term-before:
+    cons#([open_marker1, str1, open_marker2, close_marker2, str2, close_marker1]) -> Fixture(open_marker1, str1, open_marker2, close_marker2, str2, close_marker1)
+    where
+      <eq> (cons, "Fixture2") + <eq> (cons, "Fixture3") + <eq> (cons, "Fixture4")
   
   // Desugar ToPart
   desugar-term-before:

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTModule.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTModule.java
@@ -43,8 +43,8 @@ import org.metaborg.spt.core.run.ISpoofaxExpectationEvaluatorService;
 import org.metaborg.spt.core.run.ISpoofaxFragmentParser;
 import org.metaborg.spt.core.run.ISpoofaxTestCaseRunner;
 import org.metaborg.spt.core.run.SpoofaxExpectationEvaluatorService;
+import org.metaborg.spt.core.run.SpoofaxOriginFragmentParser;
 import org.metaborg.spt.core.run.SpoofaxTestCaseRunner;
-import org.metaborg.spt.core.run.SpoofaxWhitespaceFragmentParser;
 import org.metaborg.spt.core.run.expectations.AnalyzeExpectationEvaluator;
 import org.metaborg.spt.core.run.expectations.HasOriginExpectationEvaluator;
 import org.metaborg.spt.core.run.expectations.ParseExpectationEvaluator;
@@ -177,10 +177,16 @@ public class SPTModule extends MBTModule {
 
     @Override protected void configureFragmentParser() {
         // for now, we keep using the whitespace hack
-        bind(SpoofaxWhitespaceFragmentParser.class).in(Singleton.class);
-        bind(ISpoofaxFragmentParser.class).to(SpoofaxWhitespaceFragmentParser.class);
-        bind(new TypeLiteral<IFragmentParser<?>>() {}).to(SpoofaxWhitespaceFragmentParser.class);
-        bind(new TypeLiteral<IFragmentParser<ISpoofaxParseUnit>>() {}).to(SpoofaxWhitespaceFragmentParser.class);
+        // bind(SpoofaxWhitespaceFragmentParser.class).in(Singleton.class);
+        // bind(ISpoofaxFragmentParser.class).to(SpoofaxWhitespaceFragmentParser.class);
+        // bind(new TypeLiteral<IFragmentParser<?>>() {}).to(SpoofaxWhitespaceFragmentParser.class);
+        // bind(new TypeLiteral<IFragmentParser<ISpoofaxParseUnit>>() {}).to(SpoofaxWhitespaceFragmentParser.class);
+
+        // this is a test for the new fragment parser
+        bind(SpoofaxOriginFragmentParser.class).in(Singleton.class);
+        bind(ISpoofaxFragmentParser.class).to(SpoofaxOriginFragmentParser.class);
+        bind(new TypeLiteral<IFragmentParser<?>>() {}).to(SpoofaxOriginFragmentParser.class);
+        bind(new TypeLiteral<IFragmentParser<ISpoofaxParseUnit>>() {}).to(SpoofaxOriginFragmentParser.class);
     }
 
     @Override public void configureUtil() {

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTUtil.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTUtil.java
@@ -1,9 +1,5 @@
 package org.metaborg.spt.core;
 
-import java.util.List;
-
-import org.metaborg.core.source.ISourceRegion;
-import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 import org.spoofax.interpreter.terms.IStrategoAppl;
@@ -11,11 +7,11 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.terms.StrategoAnnotation;
 import org.spoofax.terms.Term;
 
-import com.google.common.collect.Lists;
-
 public class SPTUtil {
 
     private static final ILogger logger = LoggerUtils.logger(SPTUtil.class);
+
+    public static final String SOME = "Some";
 
     public static final String START_SYMBOL_CONS = "StartSymbol";
     public static final String FIXTURE_CONS = "Fixture";
@@ -85,35 +81,4 @@ public class SPTUtil {
         return b;
     }
 
-    /**
-     * Gets the outermost terms from the terms returned by the tracing service.
-     * 
-     * NOTE: assumes the outer terms are at the end of the given iterable of fragments.
-     * 
-     * @param allFragments
-     *            the terms returned from the ITracingService.
-     * @return the outermost terms.
-     */
-    public static Iterable<IStrategoTerm> outerFragments(ISpoofaxTracingService traceService,
-        Iterable<IStrategoTerm> allFragments) {
-        final List<IStrategoTerm> allTerms = Lists.newArrayList(allFragments);
-        final List<IStrategoTerm> outerTerms = Lists.newArrayList();
-        final List<ISourceRegion> regions = Lists.newArrayList();
-        // the outermost terms are at the end, as the fragments function works bottomup
-        for(int i = allTerms.size() - 1; i >= 0; i--) {
-            IStrategoTerm term = allTerms.get(i);
-            ISourceRegion region = traceService.location(term).region();
-            boolean isOuter = true;
-            for(ISourceRegion other : regions) {
-                if(other.contains(region)) {
-                    isOuter = false;
-                    break;
-                }
-            }
-            if(isOuter) {
-                outerTerms.add(term);
-            }
-        }
-        return outerTerms;
-    }
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTUtil.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTUtil.java
@@ -1,5 +1,9 @@
 package org.metaborg.spt.core;
 
+import java.util.List;
+
+import org.metaborg.core.source.ISourceRegion;
+import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 import org.spoofax.interpreter.terms.IStrategoAppl;
@@ -7,11 +11,14 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.terms.StrategoAnnotation;
 import org.spoofax.terms.Term;
 
+import com.google.common.collect.Lists;
+
 public class SPTUtil {
 
     private static final ILogger logger = LoggerUtils.logger(SPTUtil.class);
 
     public static final String START_SYMBOL_CONS = "StartSymbol";
+    public static final String FIXTURE_CONS = "Fixture";
     public static final String TEST_CONS = "Test";
     public static final String SELECTION_CONS = "Selection";
     public static final String FRAGMENT_CONS = "Fragment";
@@ -76,5 +83,37 @@ public class SPTUtil {
             b.append(term.toString());
         }
         return b;
+    }
+
+    /**
+     * Gets the outermost terms from the terms returned by the tracing service.
+     * 
+     * NOTE: assumes the outer terms are at the end of the given iterable of fragments.
+     * 
+     * @param allFragments
+     *            the terms returned from the ITracingService.
+     * @return the outermost terms.
+     */
+    public static Iterable<IStrategoTerm> outerFragments(ISpoofaxTracingService traceService,
+        Iterable<IStrategoTerm> allFragments) {
+        final List<IStrategoTerm> allTerms = Lists.newArrayList(allFragments);
+        final List<IStrategoTerm> outerTerms = Lists.newArrayList();
+        final List<ISourceRegion> regions = Lists.newArrayList();
+        // the outermost terms are at the end, as the fragments function works bottomup
+        for(int i = allTerms.size() - 1; i >= 0; i--) {
+            IStrategoTerm term = allTerms.get(i);
+            ISourceRegion region = traceService.location(term).region();
+            boolean isOuter = true;
+            for(ISourceRegion other : regions) {
+                if(other.contains(region)) {
+                    isOuter = false;
+                    break;
+                }
+            }
+            if(isOuter) {
+                outerTerms.add(term);
+            }
+        }
+        return outerTerms;
     }
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/expectations/RunStrategoToAtermExpectation.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/expectations/RunStrategoToAtermExpectation.java
@@ -1,5 +1,7 @@
 package org.metaborg.spt.core.expectations;
 
+import javax.annotation.Nullable;
+
 import org.metaborg.core.source.ISourceRegion;
 import org.metaborg.mbt.core.model.expectations.ATestExpectation;
 import org.spoofax.interpreter.terms.IStrategoTerm;
@@ -11,13 +13,17 @@ public class RunStrategoToAtermExpectation extends ATestExpectation {
 
     private final String strategy;
     private final ISourceRegion stratRegion;
+    @Nullable private final Integer selection;
+    @Nullable private final ISourceRegion selectionRegion;
     private final IStrategoTerm expectedResult;
 
     public RunStrategoToAtermExpectation(ISourceRegion region, String stratName, ISourceRegion stratRegion,
-        IStrategoTerm expectedResult) {
+        @Nullable Integer selection, @Nullable ISourceRegion selectionRegion, IStrategoTerm expectedResult) {
         super(region);
         this.strategy = stratName;
         this.stratRegion = stratRegion;
+        this.selection = selection;
+        this.selectionRegion = selectionRegion;
         this.expectedResult = expectedResult;
     }
 
@@ -33,6 +39,24 @@ public class RunStrategoToAtermExpectation extends ATestExpectation {
      */
     public ISourceRegion strategyRegion() {
         return stratRegion;
+    }
+
+    /**
+     * The reference to the selection on which the strategy should be executed.
+     * 
+     * May be null, iff the strategy should be executed on the entire fragment.
+     */
+    public @Nullable Integer selection() {
+        return selection;
+    }
+
+    /**
+     * The region of the reference to the selection on which the strategy should be executed.
+     * 
+     * May be null, iff the selection is null.
+     */
+    public @Nullable ISourceRegion selectionRegion() {
+        return selectionRegion;
     }
 
     public IStrategoTerm expectedResult() {

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseBuilder.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseBuilder.java
@@ -81,9 +81,9 @@ public class SpoofaxTestCaseBuilder implements ISpoofaxTestCaseBuilder {
         // collect the AST nodes for the test expectations
         expectationTerms = new ArrayList<>();
         for(IStrategoTerm expectation : Tools.listAt(test, 4).getAllSubterms()) {
-            if(trace.location(expectation) == null) {
-                logger.warn("No origin information on test expectation {}", expectation);
-            }
+            // if(trace.location(expectation) == null) {
+            // logger.warn("No origin information on test expectation {}", expectation);
+            // }
             expectationTerms.add(expectation);
         }
 

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseBuilder.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseBuilder.java
@@ -46,8 +46,7 @@ public class SpoofaxTestCaseBuilder implements ISpoofaxTestCaseBuilder {
 
     @Override public ISpoofaxTestCaseBuilder withTestFixture(IStrategoTerm testFixture) {
         fragmentBuilder.withFixture(testFixture);
-        // TODO: support test fixtures
-        throw new UnsupportedOperationException("Test fixtures are not supported yet.");
+        return this;
     }
 
     @Override public ISpoofaxTestCaseBuilder withResource(FileObject suiteFile) {

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/expectations/AnalyzeExpectationProvider.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/expectations/AnalyzeExpectationProvider.java
@@ -1,5 +1,7 @@
 package org.metaborg.spt.core.extract.expectations;
 
+import java.util.List;
+
 import org.metaborg.core.messages.MessageSeverity;
 import org.metaborg.core.source.ISourceLocation;
 import org.metaborg.core.source.ISourceRegion;
@@ -9,17 +11,22 @@ import org.metaborg.mbt.core.model.expectations.ITestExpectation;
 import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
 import org.metaborg.spt.core.SPTUtil;
 import org.metaborg.spt.core.extract.ISpoofaxTestExpectationProvider;
+import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.terms.Term;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
 
 public class AnalyzeExpectationProvider implements ISpoofaxTestExpectationProvider {
 
     private static final String ERR = "Errors";
+    private static final String ERR_AT = "ErrorsAt";
     private static final String WARN = "Warnings";
+    private static final String WARN_AT = "WarningsAt";
     private static final String NOTE = "Notes";
+    private static final String NOTE_AT = "NotesAt";
 
     private final ISpoofaxTracingService traceService;
 
@@ -29,31 +36,59 @@ public class AnalyzeExpectationProvider implements ISpoofaxTestExpectationProvid
 
     @Override public boolean canEvaluate(IFragment inputFragment, IStrategoTerm expectationTerm) {
         String cons = SPTUtil.consName(expectationTerm);
-        return (ERR.equals(cons) || WARN.equals(cons) || NOTE.equals(cons)) && expectationTerm.getSubtermCount() == 1
-            && Term.isTermInt(expectationTerm.getSubterm(0));
+        switch(cons) {
+            case ERR_AT:
+            case WARN_AT:
+            case NOTE_AT:
+                return expectationTerm.getSubtermCount() == 2 && Term.isTermInt(expectationTerm.getSubterm(0))
+                    && Term.isTermList(expectationTerm.getSubterm(1));
+            case ERR:
+            case WARN:
+            case NOTE:
+                return expectationTerm.getSubtermCount() == 1 && Term.isTermInt(expectationTerm.getSubterm(0));
+            default:
+                return false;
+        }
     }
 
     @Override public ITestExpectation createExpectation(IFragment inputFragment, IStrategoTerm expectationTerm) {
         final MessageSeverity severity;
-        switch(SPTUtil.consName(expectationTerm)) {
+        final String cons = SPTUtil.consName(expectationTerm);
+        switch(cons) {
             case ERR:
+            case ERR_AT:
                 // it's an Errors(n) term
                 severity = MessageSeverity.ERROR;
                 break;
             case WARN:
+            case WARN_AT:
                 // it's a Warnings(n) term
                 severity = MessageSeverity.WARNING;
                 break;
             case NOTE:
+            case NOTE_AT:
                 // it's a Notes(n) term
                 severity = MessageSeverity.NOTE;
                 break;
             default:
                 throw new IllegalArgumentException("This test expectation provider can't evaluate " + expectationTerm);
         }
+        final List<Integer> selections = Lists.newArrayList();
+        switch(cons) {
+            case ERR_AT:
+            case WARN_AT:
+            case NOTE_AT:
+                IStrategoList list = (IStrategoList) expectationTerm.getSubterm(1);
+                for(IStrategoTerm sel : list) {
+                    selections.add(Term.asJavaInt(sel));
+                }
+                break;
+            default:
+        }
         ISourceLocation loc = traceService.location(expectationTerm);
         ISourceRegion region = loc == null ? inputFragment.getRegion() : loc.region();
-        return new AnalysisMessageExpectation(region, Term.asJavaInt(expectationTerm.getSubterm(0)), severity);
+        return new AnalysisMessageExpectation(region, Term.asJavaInt(expectationTerm.getSubterm(0)), severity,
+            selections);
     }
 
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/expectations/ParseExpectationProvider.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/expectations/ParseExpectationProvider.java
@@ -10,8 +10,6 @@ import org.metaborg.spt.core.SPTUtil;
 import org.metaborg.spt.core.extract.ISpoofaxFragmentBuilder;
 import org.metaborg.spt.core.extract.ISpoofaxTestExpectationProvider;
 import org.metaborg.spt.core.run.FragmentUtil;
-import org.metaborg.util.log.ILogger;
-import org.metaborg.util.log.LoggerUtils;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 
 import com.google.inject.Inject;
@@ -21,7 +19,7 @@ import com.google.inject.Inject;
  */
 public class ParseExpectationProvider implements ISpoofaxTestExpectationProvider {
 
-    private static final ILogger logger = LoggerUtils.logger(ParseExpectationProvider.class);
+    // private static final ILogger logger = LoggerUtils.logger(ParseExpectationProvider.class);
 
     private static final String SUC = "ParseSucceeds";
     private static final String FAIL = "ParseFails";
@@ -46,7 +44,7 @@ public class ParseExpectationProvider implements ISpoofaxTestExpectationProvider
     }
 
     @Override public ITestExpectation createExpectation(IFragment inputFragment, IStrategoTerm expectationTerm) {
-        logger.debug("Creating a ParseExpectation for {}", expectationTerm);
+        // logger.debug("Creating a ParseExpectation for {}", expectationTerm);
         ISourceLocation loc = traceService.location(expectationTerm);
         ISourceRegion region = loc == null ? inputFragment.getRegion() : loc.region();
         final String cons = SPTUtil.consName(expectationTerm);

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/expectations/RunStrategoToAtermExpectationProvider.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/expectations/RunStrategoToAtermExpectationProvider.java
@@ -31,7 +31,7 @@ public class RunStrategoToAtermExpectationProvider implements ISpoofaxTestExpect
     @Override public boolean canEvaluate(IFragment inputFragment, IStrategoTerm expectationTerm) {
         String cons = SPTUtil.consName(expectationTerm);
         return Term.isTermString(expectationTerm.getSubterm(0)) && RUN_TO.equals(cons)
-            && expectationTerm.getSubtermCount() == 2 && expectationTerm.getSubterm(1).getSubtermCount() == 1;
+            && expectationTerm.getSubtermCount() == 3 && expectationTerm.getSubterm(2).getSubtermCount() == 1;
     }
 
     @Override public ITestExpectation createExpectation(IFragment inputFragment, IStrategoTerm expectationTerm) {
@@ -40,8 +40,24 @@ public class RunStrategoToAtermExpectationProvider implements ISpoofaxTestExpect
 
         final IStrategoTerm stratTerm = expectationTerm.getSubterm(0);
         final String strategy = Term.asJavaString(stratTerm);
-        final IStrategoTerm toAtermPart = expectationTerm.getSubterm(1);
-        return new RunStrategoToAtermExpectation(region, strategy, loc.region(), toAtermPart.getSubterm(0));
+        final IStrategoTerm onTerm = expectationTerm.getSubterm(1);
+        final Integer selection;
+        final ISourceRegion selectionRegion;
+        if(SPTUtil.SOME.equals(SPTUtil.consName(onTerm))) {
+            selection = Term.asJavaInt(onTerm.getSubterm(0));
+            final ISourceLocation selLoc = traceService.location(onTerm);
+            if(selLoc == null) {
+                selectionRegion = region;
+            } else {
+                selectionRegion = selLoc.region();
+            }
+        } else {
+            selection = null;
+            selectionRegion = null;
+        }
+        final IStrategoTerm toAtermPart = expectationTerm.getSubterm(2);
+        return new RunStrategoToAtermExpectation(region, strategy, loc.region(), selection, selectionRegion,
+            toAtermPart.getSubterm(0));
     }
 
 }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxOriginFragmentParser.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxOriginFragmentParser.java
@@ -1,0 +1,168 @@
+package org.metaborg.spt.core.run;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.core.syntax.ParseException;
+import org.metaborg.mbt.core.model.IFragment;
+import org.metaborg.mbt.core.model.IFragment.FragmentPiece;
+import org.metaborg.mbt.core.run.IFragmentParserConfig;
+import org.metaborg.spoofax.core.syntax.ISpoofaxSyntaxService;
+import org.metaborg.spoofax.core.syntax.JSGLRParserConfiguration;
+import org.metaborg.spoofax.core.unit.ISpoofaxInputUnit;
+import org.metaborg.spoofax.core.unit.ISpoofaxInputUnitService;
+import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
+import org.metaborg.util.log.ILogger;
+import org.metaborg.util.log.LoggerUtils;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr.client.imploder.IToken;
+import org.spoofax.jsglr.client.imploder.ITokenizer;
+import org.spoofax.jsglr.client.imploder.ImploderAttachment;
+import org.spoofax.jsglr.client.imploder.Token;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+
+/**
+ * Parser for fragments of non-layout sensitive languages.
+ * 
+ * Ensures the correct offsets of the parse result by post processing the parse result and updating origins. Updating
+ * origins happens by updating the offsets of the tokens of the AST's tokenizer. This requires quite heavy knowledge of
+ * the Spoofax internals, so we could use an API for changing origin locations and not just querying them.
+ */
+public class SpoofaxOriginFragmentParser implements ISpoofaxFragmentParser {
+
+    private static final ILogger logger = LoggerUtils.logger(SpoofaxOriginFragmentParser.class);
+
+    private final ISpoofaxInputUnitService inputService;
+    private final ISpoofaxSyntaxService parseService;
+
+    @Inject public SpoofaxOriginFragmentParser(ISpoofaxInputUnitService inputService,
+        ISpoofaxSyntaxService parseService) {
+        this.inputService = inputService;
+        this.parseService = parseService;
+    }
+
+    @Override public ISpoofaxParseUnit parse(IFragment fragment, ILanguageImpl language,
+        @Nullable ILanguageImpl dialect, @Nullable ISpoofaxFragmentParserConfig config) throws ParseException {
+
+        final Iterable<FragmentPiece> fragmentPieces = fragment.getText();
+        StringBuilder textBuilder = new StringBuilder();
+        final List<OffsetAdjustment> gaps = Lists.newLinkedList();
+
+        // record the text and the gaps in the text
+        int textOffset = 0;
+        int adjustedOffset = 0;
+        for(FragmentPiece piece : fragmentPieces) {
+            if(piece.startOffset > adjustedOffset) {
+                // there is a gap between the last piece and this piece
+                adjustedOffset = piece.startOffset;
+                gaps.add(new OffsetAdjustment(textOffset, adjustedOffset - textOffset));
+            } else if(piece.startOffset < adjustedOffset) {
+                // this doesn't make any sense, the pieces should be ordered by offset.
+                throw new IllegalStateException(
+                    String.format("Can't process a fragment with inconsistent fragment pieces at (%1$s, %2$s).",
+                        piece.startOffset, piece.text));
+            }
+            adjustedOffset += piece.text.length();
+            textOffset += piece.text.length();
+            textBuilder.append(piece.text);
+        }
+
+        // now we can parse the fragment
+        final ISpoofaxInputUnit input;
+        JSGLRParserConfiguration pConfig = null;
+        if(config != null) {
+            pConfig = config.getParserConfigForLanguage(language);
+        }
+        if(pConfig == null) {
+            input = inputService.inputUnit(fragment.getResource(), textBuilder.toString(), language, dialect);
+        } else {
+            input = inputService.inputUnit(fragment.getResource(), textBuilder.toString(), language, dialect, pConfig);
+        }
+
+        ISpoofaxParseUnit p = parseService.parse(input);
+
+        // short circuit if there was no result
+        if(!p.valid()) {
+            return p;
+        }
+        IStrategoTerm ast = p.ast();
+        if(ast == null) {
+            return p;
+        }
+
+        // start changing the offsets by changing the offsets of the tokens
+        ITokenizer itokenizer = ImploderAttachment.getTokenizer(ast);
+        if(itokenizer == null) {
+            logger.warn("Found a fragment with no tokenizer! Can't update the offsets. \"{}\"", textBuilder);
+            return p;
+        }
+
+        Iterator<OffsetAdjustment> gapIt = gaps.iterator();
+        if(!gapIt.hasNext()) {
+            return p;
+        }
+
+        OffsetAdjustment nextGap = gapIt.next();
+        int oldAdjustment = 0;
+        for(IToken itoken : itokenizer) {
+            if(!(itoken instanceof Token)) {
+                logger.error(
+                    "Unable to properly update the offsets of the fragment, as it has an unknown token implementation ({}). Fragment: \"{}\"",
+                    itoken.getClass(), textBuilder);
+                return p;
+            }
+
+            final int adjustment;
+            if(nextGap == null || itoken.getStartOffset() < nextGap.normalOffset) {
+                adjustment = oldAdjustment;
+            } else {
+                // update to the next gap and record the adjustment to use at the moment
+                while(nextGap != null && itoken.getStartOffset() >= nextGap.normalOffset) {
+                    oldAdjustment = nextGap.adjustment;
+                    nextGap = gapIt.hasNext() ? gapIt.next() : null;
+                }
+                adjustment = oldAdjustment;
+            }
+            if(adjustment > 0) {
+                ((Token) itoken).setStartOffset(itoken.getStartOffset() + adjustment);
+                ((Token) itoken).setEndOffset(itoken.getEndOffset() + adjustment);
+            }
+        }
+
+        // now the offsets of the tokens are updated
+        // changing the state like this should update the offsets of the nodes automatically
+        return p;
+    }
+
+    @Override public ISpoofaxParseUnit parse(IFragment fragment, ILanguageImpl language, ILanguageImpl dialect,
+        IFragmentParserConfig config) throws ParseException {
+        if(config == null || !(config instanceof ISpoofaxFragmentParserConfig)) {
+            return parse(fragment, language, dialect, (ISpoofaxFragmentParserConfig) null);
+        } else {
+            return parse(fragment, language, dialect, (ISpoofaxFragmentParserConfig) config);
+        }
+    }
+
+    /**
+     * Represents a gap in the fragment text.
+     * 
+     * This means that any text at or after the normalOffset should be updated to be at normalOffset + adjustment.
+     */
+    private static class OffsetAdjustment {
+        // the offset within the text, starting at 0
+        public final int normalOffset;
+        // the adjustment that has to be added to the normalOffset
+        public final int adjustment;
+
+        public OffsetAdjustment(int offset, int adjustment) {
+            this.normalOffset = offset;
+            this.adjustment = adjustment;
+        }
+    }
+
+}

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxOriginFragmentParser.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/SpoofaxOriginFragmentParser.java
@@ -1,6 +1,7 @@
 package org.metaborg.spt.core.run;
 
-import java.util.Iterator;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -28,12 +29,13 @@ import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr.client.imploder.ITokenizer;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.jsglr.client.imploder.Token;
+import org.spoofax.jsglr.client.imploder.Tokenizer;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
 /**
- * Parser for fragments of non-layout sensitive languages.
+ * Parser for fragments languages.
  * 
  * Ensures the correct offsets of the parse result by post processing the parse result and updating origins. Updating
  * origins happens by updating the offsets of the tokens of the AST's tokenizer. This requires quite heavy knowledge of
@@ -57,28 +59,14 @@ public class SpoofaxOriginFragmentParser implements ISpoofaxFragmentParser {
     @Override public ISpoofaxParseUnit parse(IFragment fragment, ILanguageImpl language,
         @Nullable ILanguageImpl dialect, @Nullable ISpoofaxFragmentParserConfig config) throws ParseException {
 
+        // record the text of the fragment
         final Iterable<FragmentPiece> fragmentPieces = fragment.getText();
         StringBuilder textBuilder = new StringBuilder();
-        final List<OffsetAdjustment> gaps = Lists.newLinkedList();
-
-        // record the text and the gaps in the text
-        int textOffset = 0;
-        int adjustedOffset = 0;
         for(FragmentPiece piece : fragmentPieces) {
-            if(piece.startOffset > adjustedOffset) {
-                // there is a gap between the last piece and this piece
-                adjustedOffset = piece.startOffset;
-                gaps.add(new OffsetAdjustment(textOffset, adjustedOffset - textOffset));
-            } else if(piece.startOffset < adjustedOffset) {
-                // this doesn't make any sense, the pieces should be ordered by offset.
-                throw new IllegalStateException(
-                    String.format("Can't process a fragment with inconsistent fragment pieces at (%1$s, %2$s).",
-                        piece.startOffset, piece.text));
-            }
-            adjustedOffset += piece.text.length();
-            textOffset += piece.text.length();
             textBuilder.append(piece.text);
         }
+        final String textStr = textBuilder.toString();
+
 
         // now we can parse the fragment
         final ISpoofaxInputUnit input;
@@ -86,10 +74,11 @@ public class SpoofaxOriginFragmentParser implements ISpoofaxFragmentParser {
         if(config != null) {
             pConfig = config.getParserConfigForLanguage(language);
         }
+
         if(pConfig == null) {
-            input = inputService.inputUnit(fragment.getResource(), textBuilder.toString(), language, dialect);
+            input = inputService.inputUnit(fragment.getResource(), textStr, language, dialect);
         } else {
-            input = inputService.inputUnit(fragment.getResource(), textBuilder.toString(), language, dialect, pConfig);
+            input = inputService.inputUnit(fragment.getResource(), textStr, language, dialect, pConfig);
         }
 
         ISpoofaxParseUnit p = parseService.parse(input);
@@ -106,41 +95,67 @@ public class SpoofaxOriginFragmentParser implements ISpoofaxFragmentParser {
         // start changing the offsets by changing the offsets of the tokens
         ITokenizer itokenizer = ImploderAttachment.getTokenizer(ast);
         if(itokenizer == null) {
-            logger.warn("Found a fragment with no tokenizer! Can't update the offsets. \"{}\"", textBuilder);
+            logger.warn("Found a fragment with no tokenizer! Can't update the offsets. \"{}\"", textStr);
             return p;
         }
 
-        Iterator<OffsetAdjustment> gapIt = gaps.iterator();
-        if(!gapIt.hasNext()) {
-            return p;
-        }
-
-        OffsetAdjustment nextGap = gapIt.next();
-        int oldAdjustment = 0;
-        for(IToken itoken : itokenizer) {
-            if(!(itoken instanceof Token)) {
-                logger.error(
-                    "Unable to properly update the offsets of the fragment, as it has an unknown token implementation ({}). Fragment: \"{}\"",
-                    itoken.getClass(), textBuilder);
-                return p;
-            }
-
-            final int adjustment;
-            if(nextGap == null || itoken.getStartOffset() < nextGap.normalOffset) {
-                adjustment = oldAdjustment;
-            } else {
-                // update to the next gap and record the adjustment to use at the moment
-                while(nextGap != null && itoken.getStartOffset() >= nextGap.normalOffset) {
-                    oldAdjustment = nextGap.adjustment;
-                    nextGap = gapIt.hasNext() ? gapIt.next() : null;
+        // adjust the tokens for each piece of the fragment
+        // this makes NO assumptions about the order of the startOffsets of the token stream
+        // it DOES assume that the pieces of text of the fragment are ordered based on the correct order of text
+        int[] startOffsets = new int[itokenizer.getTokenCount()];
+        int[] endOffsets = new int[itokenizer.getTokenCount()];
+        int currStartOffsetOfPiece = 0;
+        int currEndOffsetOfPiece = 0;
+        for(FragmentPiece piece : fragmentPieces) {
+            int pieceLength = piece.text.length();
+            currEndOffsetOfPiece = currStartOffsetOfPiece + pieceLength - 1;
+            int adjustment = piece.startOffset - currStartOffsetOfPiece;
+            for(IToken itoken : itokenizer) {
+                int startOffset = itoken.getStartOffset();
+                if(startOffset >= currStartOffsetOfPiece && startOffset <= currEndOffsetOfPiece) {
+                    Token token = (Token) itoken;
+                    startOffsets[token.getIndex()] = startOffset + adjustment;
+                    endOffsets[token.getIndex()] = token.getEndOffset() + adjustment;
                 }
-                adjustment = oldAdjustment;
             }
-            if(adjustment > 0) {
-                ((Token) itoken).setStartOffset(itoken.getStartOffset() + adjustment);
-                ((Token) itoken).setEndOffset(itoken.getEndOffset() + adjustment);
+            currStartOffsetOfPiece += pieceLength;
+        }
+
+        // Do post processing to ensure the token stream is ordered by offsets again
+        final List<Token> tokens = Lists.newArrayList();
+        Token eof = null;
+        for(IToken itoken : itokenizer) {
+            if(IToken.TK_EOF == itoken.getKind()) {
+                eof = (Token) itoken;
+            } else {
+                Token token = (Token) itoken;
+                token.setStartOffset(startOffsets[token.getIndex()]);
+                token.setEndOffset(endOffsets[token.getIndex()]);
+                tokens.add(token);
             }
         }
+        Collections.sort(tokens, new Comparator<IToken>() {
+            @Override public int compare(IToken o1, IToken o2) {
+                int r = o1.getStartOffset() - o2.getStartOffset();
+                if(r == 0) {
+                    r = o1.getEndOffset() - o2.getEndOffset();
+                }
+                return r;
+            }
+        });
+        int lastOffset = tokens.get(tokens.size() - 1).getEndOffset();
+        eof.setStartOffset(lastOffset + 1);
+        eof.setEndOffset(lastOffset);
+        tokens.add(eof);
+
+        Tokenizer newTokenizer = new Tokenizer(itokenizer.getInput(), itokenizer.getFilename(), null, false);
+        for(Token token : tokens) {
+            // NOTE: this will break if run with assertions turned on
+            // but as this entire approach is one big hack, I don't really care at the moment
+            newTokenizer.reassignToken(token);
+        }
+        newTokenizer.setAst(ast);
+        newTokenizer.initAstNodeBinding();
 
         // now the offsets of the tokens are updated
         // changing the state like this should update the offsets of the ast nodes automatically
@@ -151,21 +166,23 @@ public class SpoofaxOriginFragmentParser implements ISpoofaxFragmentParser {
             if(region == null) {
                 continue;
             }
-            int startAdjustment = 0;
-            int endAdjustment = 0;
-            for(OffsetAdjustment gap : gaps) {
-                if(gap.normalOffset <= region.startOffset()) {
-                    startAdjustment = gap.adjustment;
+            int newStart = region.startOffset();
+            int newEnd = region.endOffset();
+            int offset = 0;
+            for(FragmentPiece piece : fragmentPieces) {
+                int startOffset = region.startOffset();
+                int pieceEndExclusive = offset + piece.text.length();
+                if(startOffset >= offset && startOffset < pieceEndExclusive) {
+                    newStart = piece.startOffset + (startOffset - offset);
                 }
-                if(gap.normalOffset <= region.endOffset()) {
-                    endAdjustment = gap.adjustment;
-                } else {
-                    break;
+                int endOffset = region.endOffset();
+                if(endOffset >= offset && endOffset < pieceEndExclusive) {
+                    newEnd = piece.startOffset + (endOffset - offset);
                 }
+                offset += piece.text.length();
             }
-            if(startAdjustment > 0 || endAdjustment > 0) {
-                ISourceRegion newRegion =
-                    new SourceRegion(region.startOffset() + startAdjustment, region.endOffset() + endAdjustment);
+            if(newStart != region.startOffset() || newEnd != region.endOffset()) {
+                ISourceRegion newRegion = new SourceRegion(newStart, newEnd);
                 changedMessages.add(MessageUtil.setRegion(m, newRegion));
             }
         }
@@ -179,23 +196,6 @@ public class SpoofaxOriginFragmentParser implements ISpoofaxFragmentParser {
             return parse(fragment, language, dialect, (ISpoofaxFragmentParserConfig) null);
         } else {
             return parse(fragment, language, dialect, (ISpoofaxFragmentParserConfig) config);
-        }
-    }
-
-    /**
-     * Represents a gap in the fragment text.
-     * 
-     * This means that any text at or after the normalOffset should be updated to be at normalOffset + adjustment.
-     */
-    private static class OffsetAdjustment {
-        // the offset within the text, starting at 0
-        public final int normalOffset;
-        // the adjustment that has to be added to the normalOffset
-        public final int adjustment;
-
-        public OffsetAdjustment(int offset, int adjustment) {
-            this.normalOffset = offset;
-            this.adjustment = adjustment;
         }
     }
 

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
@@ -27,15 +27,7 @@ import com.google.common.collect.Lists;
 public class AnalyzeExpectationEvaluator implements ISpoofaxExpectationEvaluator<AnalysisMessageExpectation> {
 
     @Override public Collection<Integer> usesSelections(IFragment fragment, AnalysisMessageExpectation expectation) {
-        // we claim the first n selections for an 'n errors' expectation
-        Collection<Integer> used = Lists.newLinkedList();
-        // but only if there are enough selections
-        if(fragment.getSelections().size() >= expectation.num()) {
-            for(int i = 0; i < expectation.num(); i++) {
-                used.add(i);
-            }
-        }
-        return used;
+        return Lists.newArrayList(expectation.selections());
     }
 
     @Override public TestPhase getPhase(IContext unused, AnalysisMessageExpectation expectation) {

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
@@ -74,17 +74,17 @@ public class AnalyzeExpectationEvaluator implements ISpoofaxExpectationEvaluator
      * Check if the number of messages in the given analysisMessages of the given severity matches the given expected
      * number of messages of this severity.
      * 
-     * Also checks if all selections of the test case capture a message of the given severity. It is allowed to have
-     * uncaptured messages, but it's not allowed to have selection that don't capture a message. A selection captures a
-     * message if the selection's region contains the message's region. Note that this means that selection are allowed
-     * to be wider than the actual message!
+     * Only considers messages that are within the bounds of the fragment (so it ignores any messages that are on the
+     * test fixture).
+     * 
+     * TODO: support syntax like 'n errors on #i, #j' to make sure the locations of the messages are correct too.
      */
     private boolean checkMessages(ITestCase test, Iterable<IMessage> analysisMessages, MessageSeverity severity,
         int expectedNumMessages, Collection<IMessage> messages) {
-        // collect the messages of the given severity
+        // collect the messages of the given severity and proper location
         List<IMessage> interestingMessages = Lists.newLinkedList();
         for(IMessage message : analysisMessages) {
-            if(severity == message.severity()) {
+            if(severity == message.severity() && test.getFragment().getRegion().contains(message.region())) {
                 interestingMessages.add(message);
             }
         }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
@@ -7,7 +7,6 @@ import org.metaborg.core.context.IContext;
 import org.metaborg.core.messages.IMessage;
 import org.metaborg.core.messages.MessageFactory;
 import org.metaborg.core.messages.MessageSeverity;
-import org.metaborg.core.source.ISourceRegion;
 import org.metaborg.mbt.core.model.IFragment;
 import org.metaborg.mbt.core.model.ITestCase;
 import org.metaborg.mbt.core.model.TestPhase;
@@ -96,23 +95,27 @@ public class AnalyzeExpectationEvaluator implements ISpoofaxExpectationEvaluator
                 "Expected " + expectedNumMessages + " " + severity + "s, but got " + interestingMessages.size(), null));
         }
 
-        /*
-         * Check if all selections capture a message we are interested in. Not all messages have to be captured by a
-         * selection, but all selections have to capture an interesting message.
-         */
-        for(ISourceRegion selection : test.getFragment().getSelections()) {
-            boolean found = false;
-            for(IMessage error : interestingMessages) {
-                if(error.region() != null && selection.contains(error.region())) {
-                    found = true;
-                    break;
-                }
-            }
-            if(!found) {
-                messages.add(MessageFactory.newAnalysisError(test.getResource(), selection,
-                    "Expected an " + severity + " at this selection, but didn't find one.", null));
-            }
-        }
+        // TODO: FIXME:
+        // in the future, the selections have to be explicitly specified by the expectation
+        // for example: 1 error at #2
+        // or : 2 errors at #1,#3
+        // /*
+        // * Check if all selections capture a message we are interested in. Not all messages have to be captured by a
+        // * selection, but all selections have to capture an interesting message.
+        // */
+        // for(ISourceRegion selection : test.getFragment().getSelections()) {
+        // boolean found = false;
+        // for(IMessage error : interestingMessages) {
+        // if(error.region() != null && selection.contains(error.region())) {
+        // found = true;
+        // break;
+        // }
+        // }
+        // if(!found) {
+        // messages.add(MessageFactory.newAnalysisError(test.getResource(), selection,
+        // "Expected an " + severity + " at this selection, but didn't find one.", null));
+        // }
+        // }
 
         if(messages.isEmpty()) {
             return true;

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/HasOriginExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/HasOriginExpectationEvaluator.java
@@ -60,7 +60,7 @@ public class HasOriginExpectationEvaluator implements ISpoofaxExpectationEvaluat
         ISpoofaxAnalyzeUnit a = input.getFragmentResult().getAnalysisResult();
         if(a == null || !a.valid() || !a.hasAst()) {
             messages.add(MessageFactory.newAnalysisError(test.getResource(), test.getDescriptionRegion(),
-                "An analyzed AST is required to check origin location.", null));
+                "An analyzed AST is required to check origin locations.", null));
             return new SpoofaxTestExpectationOutput(false, messages, fragmentResults);
         }
 

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ParseExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ParseExpectationEvaluator.java
@@ -102,7 +102,8 @@ public class ParseExpectationEvaluator implements ISpoofaxExpectationEvaluator<P
             if(parsedFragment == null) {
                 success = false;
             } else {
-                ILanguage outputLang = fragmentUtil.getLanguage(expectation.outputLanguage(), messages, test);
+                ILanguage outputLang = expectation.outputLanguage() == null ? input.getLanguageUnderTest().belongsTo()
+                    : fragmentUtil.getLanguage(expectation.outputLanguage(), messages, test);
                 if(outputLang != null && !TermEqualityUtil.equalsIgnoreAnnos(p.ast(), parsedFragment.ast(),
                     termFactoryService.get(outputLang.activeImpl(), test.getProject(), false))) {
                     // TODO: add a nice diff of the two parse results or something

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ParseToAtermExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ParseToAtermExpectationEvaluator.java
@@ -16,13 +16,14 @@ import org.metaborg.spoofax.core.terms.ITermFactoryService;
 import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
-import org.metaborg.spt.core.SPTUtil;
 import org.metaborg.spt.core.expectations.ParseToAtermExpectation;
 import org.metaborg.spt.core.run.ISpoofaxExpectationEvaluator;
 import org.metaborg.spt.core.run.ISpoofaxFragmentResult;
 import org.metaborg.spt.core.run.ISpoofaxTestExpectationOutput;
 import org.metaborg.spt.core.run.SpoofaxTestExpectationOutput;
 import org.metaborg.util.iterators.Iterables2;
+import org.metaborg.util.log.ILogger;
+import org.metaborg.util.log.LoggerUtils;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.strategoxt.lang.TermEqualityUtil;
 
@@ -33,6 +34,8 @@ import com.google.inject.Inject;
  * Check if the input fragment parsed to the expected ATerm AST.
  */
 public class ParseToAtermExpectationEvaluator implements ISpoofaxExpectationEvaluator<ParseToAtermExpectation> {
+
+    private static final ILogger logger = LoggerUtils.logger(ParseToAtermExpectationEvaluator.class);
 
     private final ITermFactoryService termFactoryService;
     private final ISpoofaxTracingService traceService;
@@ -69,7 +72,8 @@ public class ParseToAtermExpectationEvaluator implements ISpoofaxExpectationEval
         // compare the parse result
         // but only the part of the test's fragment, not the parts of the test fixture
         ISourceRegion fragmentRegion = test.getFragment().getRegion();
-        Iterable<IStrategoTerm> terms = SPTUtil.outerFragments(traceService, traceService.fragments(p, fragmentRegion));
+        Iterable<IStrategoTerm> terms = traceService.fragmentsWithin(p, fragmentRegion);
+        logger.debug("Fragment region: {}\nFragment terms: {}", fragmentRegion, terms);
         boolean success = false;
         String latestMessage = "The fragment was empty.";
         for(IStrategoTerm term : terms) {

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ParseToAtermExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ParseToAtermExpectationEvaluator.java
@@ -7,19 +7,23 @@ import java.util.List;
 import org.metaborg.core.context.IContext;
 import org.metaborg.core.messages.IMessage;
 import org.metaborg.core.messages.MessageFactory;
+import org.metaborg.core.source.ISourceRegion;
 import org.metaborg.mbt.core.model.IFragment;
 import org.metaborg.mbt.core.model.ITestCase;
 import org.metaborg.mbt.core.model.TestPhase;
 import org.metaborg.mbt.core.run.ITestExpectationInput;
 import org.metaborg.spoofax.core.terms.ITermFactoryService;
+import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
+import org.metaborg.spt.core.SPTUtil;
 import org.metaborg.spt.core.expectations.ParseToAtermExpectation;
 import org.metaborg.spt.core.run.ISpoofaxExpectationEvaluator;
 import org.metaborg.spt.core.run.ISpoofaxFragmentResult;
 import org.metaborg.spt.core.run.ISpoofaxTestExpectationOutput;
 import org.metaborg.spt.core.run.SpoofaxTestExpectationOutput;
 import org.metaborg.util.iterators.Iterables2;
+import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.strategoxt.lang.TermEqualityUtil;
 
 import com.google.common.collect.Lists;
@@ -31,9 +35,12 @@ import com.google.inject.Inject;
 public class ParseToAtermExpectationEvaluator implements ISpoofaxExpectationEvaluator<ParseToAtermExpectation> {
 
     private final ITermFactoryService termFactoryService;
+    private final ISpoofaxTracingService traceService;
 
-    @Inject public ParseToAtermExpectationEvaluator(ITermFactoryService termFactoryService) {
+    @Inject public ParseToAtermExpectationEvaluator(ITermFactoryService termFactoryService,
+        ISpoofaxTracingService traceService) {
         this.termFactoryService = termFactoryService;
+        this.traceService = traceService;
     }
 
     @Override public Collection<Integer> usesSelections(IFragment fragment, ParseToAtermExpectation expectation) {
@@ -49,7 +56,6 @@ public class ParseToAtermExpectationEvaluator implements ISpoofaxExpectationEval
 
         ISpoofaxParseUnit p = input.getFragmentResult().getParseResult();
         ITestCase test = input.getTestCase();
-        final boolean success;
 
         List<IMessage> messages = new LinkedList<>();
         Iterable<ISpoofaxFragmentResult> fragmentResults = Iterables2.empty();
@@ -61,14 +67,25 @@ public class ParseToAtermExpectationEvaluator implements ISpoofaxExpectationEval
         }
 
         // compare the parse result
-        success = TermEqualityUtil.equalsIgnoreAnnos(p.ast(), expectation.expectedResult(),
-            termFactoryService.get(input.getLanguageUnderTest(), test.getProject(), false));
-        if(!success) {
-            messages.add(MessageFactory.newAnalysisError(test.getResource(), test.getDescriptionRegion(),
-                String.format(
+        // but only the part of the test's fragment, not the parts of the test fixture
+        ISourceRegion fragmentRegion = test.getFragment().getRegion();
+        Iterable<IStrategoTerm> terms = SPTUtil.outerFragments(traceService, traceService.fragments(p, fragmentRegion));
+        boolean success = false;
+        String latestMessage = "The fragment was empty.";
+        for(IStrategoTerm term : terms) {
+            if(TermEqualityUtil.equalsIgnoreAnnos(term, expectation.expectedResult(),
+                termFactoryService.get(input.getLanguageUnderTest(), test.getProject(), false))) {
+                success = true;
+                break;
+            } else {
+                latestMessage = String.format(
                     "The fragment did not parse to the expected ATerm.\nParse result was: %1$s\nExpected result was: %2$s",
-                    p.ast(), expectation.expectedResult()),
-                null));
+                    term, expectation.expectedResult());
+            }
+        }
+        if(!success) {
+            messages.add(
+                MessageFactory.newAnalysisError(test.getResource(), test.getDescriptionRegion(), latestMessage, null));
         }
         return new SpoofaxTestExpectationOutput(success, messages, fragmentResults);
     }

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/RunStrategoExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/RunStrategoExpectationEvaluator.java
@@ -1,6 +1,7 @@
 package org.metaborg.spt.core.run.expectations;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.metaborg.core.MetaborgException;
@@ -23,7 +24,6 @@ import org.metaborg.spoofax.core.terms.ITermFactoryService;
 import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
-import org.metaborg.spt.core.SPTUtil;
 import org.metaborg.spt.core.run.FragmentUtil;
 import org.metaborg.spt.core.run.ISpoofaxExpectationEvaluator;
 import org.metaborg.spt.core.run.ISpoofaxFragmentResult;
@@ -60,13 +60,9 @@ public class RunStrategoExpectationEvaluator implements ISpoofaxExpectationEvalu
         this.fragmentUtil = fragmentUtil;
     }
 
-    @Override public Collection<Integer> usesSelections(IFragment fragment, RunStrategoExpectation expectation) {
-        List<Integer> used = Lists.newLinkedList();
-        // we use the first selection (if any)
-        if(!fragment.getSelections().isEmpty()) {
-            used.add(0);
-        }
-        return used;
+    @SuppressWarnings("unchecked") @Override public Collection<Integer> usesSelections(IFragment fragment,
+        RunStrategoExpectation expectation) {
+        return expectation.selection() == null ? Collections.EMPTY_LIST : Lists.newArrayList(expectation.selection());
     }
 
     @Override public TestPhase getPhase(IContext languageUnderTestCtx, RunStrategoExpectation expectation) {
@@ -126,21 +122,19 @@ public class RunStrategoExpectationEvaluator implements ISpoofaxExpectationEvalu
          * starting on the outermost term, until we processed them all or one of them passed successfully.
          */
         List<IStrategoTerm> terms = Lists.newLinkedList();
-        if(selections.isEmpty()) {
+        if(expectation.selection() == null) {
             // no selections, so we run on the entire ast
             // but only on the part that is inside the actual fragment, not the fixture
-            for(IStrategoTerm term : SPTUtil.outerFragments(traceService,
-                traceService.fragments(analysisResult, test.getFragment().getRegion()))) {
+            for(IStrategoTerm term : traceService.fragmentsWithin(analysisResult, test.getFragment().getRegion())) {
                 terms.add(term);
             }
-        } else if(selections.size() > 1) {
-            // too many selections, we don't know which to select as input
-            messages.add(MessageFactory.newAnalysisError(test.getResource(), test.getDescriptionRegion(),
-                "Too many selections in this test case, we don't know which selection you want to use as input.",
-                null));
+        } else if(expectation.selection() > selections.size()) {
+            // not enough selections to resolve it
+            messages.add(MessageFactory.newAnalysisError(test.getResource(), expectation.selectionRegion(),
+                "Not enough selections to resolve #" + expectation.selection(), null));
         } else {
             // the input should be the selected term
-            ISourceRegion selection = selections.get(0);
+            ISourceRegion selection = selections.get(expectation.selection() - 1);
             for(IStrategoTerm possibleSelection : traceService.fragments(analysisResult, selection)) {
                 ISourceLocation loc = traceService.location(possibleSelection);
                 // the region should match exactly

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/RunStrategoToAtermExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/RunStrategoToAtermExpectationEvaluator.java
@@ -21,6 +21,7 @@ import org.metaborg.spoofax.core.terms.ITermFactoryService;
 import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
+import org.metaborg.spt.core.SPTUtil;
 import org.metaborg.spt.core.expectations.RunStrategoToAtermExpectation;
 import org.metaborg.spt.core.run.ISpoofaxExpectationEvaluator;
 import org.metaborg.spt.core.run.ISpoofaxFragmentResult;
@@ -128,7 +129,11 @@ public class RunStrategoToAtermExpectationEvaluator
         List<IStrategoTerm> terms = Lists.newLinkedList();
         if(selections.isEmpty()) {
             // no selections, so we run on the entire ast
-            terms.add(analysisResult.ast());
+            // but only on the part that is inside the actual fragment, not the fixture
+            for(IStrategoTerm term : SPTUtil.outerFragments(traceService,
+                traceService.fragments(analysisResult, test.getFragment().getRegion()))) {
+                terms.add(term);
+            }
         } else if(selections.size() > 1) {
             // too many selections, we don't know which to select as input
             logger.debug(

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/RunStrategoToAtermExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/RunStrategoToAtermExpectationEvaluator.java
@@ -141,11 +141,11 @@ public class RunStrategoToAtermExpectationEvaluator
             ISourceRegion selection = selections.get(0);
             for(IStrategoTerm possibleSelection : traceService.fragments(analysisResult, selection)) {
                 ISourceLocation loc = traceService.location(possibleSelection);
-                logger.debug("Checking possible selected term {} with location {}", possibleSelection, loc);
+                // logger.debug("Checking possible selected term {} with location {}", possibleSelection, loc);
                 // the region should match exactly
                 if(loc != null && loc.region().startOffset() == selection.startOffset()
                     && loc.region().endOffset() == selection.endOffset()) {
-                    logger.debug("Matched, adding it as input node to the strategy");
+                    // logger.debug("Matched, adding it as input node to the strategy");
                     terms.add(possibleSelection);
                 }
             }


### PR DESCRIPTION
These commits change 3 things:

1. add back setup blocks as test fixtures
2. make the use of selections explicit
3. add a faster parser for tests

## Setup blocks (test fixtures now)

The old `setup` blocks are replaced by `fixture`s as described in the original SPT paper.

```
fixture [[
  some code you want before each test case

  [[...]]

  some code you want after each test case
]]
```

where `[[...]]` is the place where the fragment of each test case gets inserted.
Note that this influences some of the test expectations.

`parse to Some(Aterm())` expectations will now be compared only to the AST nodes within the fragment of the test case. So **not** to the nodes in the test fixture.
This was done because each test case should contain most of its information in the test itself.
The fixture is just a way to reduce boilerplate code.
For the same reason, you can't make selections in the test fixtures.

`n errors` expectations will now only look at errors from within the fragment itself.
This means that any analysis errors in the test fixture will **not** be counted amongst the `n` that was supplied.
Again, the reason for this is to have test cases be as self contained as possible.

`Run my-strategy to ...` expectations will run the strategy only on the AST nodes within the test case itself. If multiple nodes exist (e.g. the fragment consists of a set of statements), the strategy will be applied to each node until the test passes or all such nodes have been tried.
The strategy will **not** be applied to nodes in the test fixture.

`transform "menu -> transformation" to ...` expectations **will** be applied on the entire AST (*including the fixture*).
The reason for this is that transformations are menu items that are usually invoked on the entire specification, so (as far as I know) it does not really make sense to apply them only to a the fragment.

## Explicit selections

References to selections from expectations are now all explicit.

The first example of explicit references to selections was the `resolve #i to #j` expectation.

The same has been added to:

`3 errors at #1, #2` Where the fragment should contain 3 errors, one of which should be at the location of selection 1 and another at selection `#2`. We do not care where the third error is.

`run my-strat on #3 to ...` Where the strategy will only be applied to the term at the selection.

## Faster parser

I have confirmed that the old trick of adding spaces instead of all the characters in front of a test case to keep the offsets of the parse result intact (i.e., the whitespace hack), was the cause of slow tests.
If 2000 characters preceded the test case, parsing would take more than half a second, as opposed to 5ms for parsing only the test.

The new parser parses only the text and then modifies the token stream (i.e. parse stream) and the messages of the parse result afterwards, to get correct offsets.
This new approach still causes some slowdown (8ms instead of 5ms in my test), but it also allows the use of test fixtures.

What makes test fixtures interesting is that it means each test consists of three parts (technically even more, but ignore the details for now):

1. the part of the fixture before the 'insertion' of the test case fragment
2. the test case fragment
3. the part of the fixture after the 'insertion'

However, these parts are located in the SPT file in the order [1,3,2].
So the parse result will give you a token stream in the order [1,2,3], but then I fix the offsets and reorder the token stream to be in the order [1,3,2].
Who knows what kind of hideous corner cases this could break, but for now it works.
You do have to be careful with using the tracing service, as any node that starts before part 2 and ends after part 2, will have a region before any term inside part 2, which might be conceptually unintuitive.
It basically means that you can't assume that a node's children are all contained within the region of the node.

If we don't want to deal with things like that, we can't use test fixtures and have to move back to setup blocks.