### PR TITLE
Allow newlines in ATerm strings

### DIFF
--- a/org.metaborg.meta.lang.spt/syntax/spt/ATerm.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/ATerm.sdf3
@@ -11,7 +11,7 @@ TermList.List = <[<{Term ", "}*>]>
 
 Term.Appl = <<ID>(<{MidTerm ", "}*>)>
 Term.Int = <<INT>>
-Term.String = <<STRING>>
+Term.String = <<ASTRING>>
 Term.Wld = <_>
 
 PreTerm = TermList
@@ -24,3 +24,10 @@ MidTerm = TermAnno
 ATerm = TermAnno
 ATerm = Term
 ATerm = <!ATerm <TermList>>
+
+lexical syntax
+
+  ASTRING         = "\"" AStringChar* "\"" 
+  AStringChar     = ~[\"] 
+  AStringChar     = "\\\"" 
+  AStringChar     = BackSlashChar 

--- a/org.metaborg.spt.test/transform/transform.spt
+++ b/org.metaborg.spt.test/transform/transform.spt
@@ -24,4 +24,9 @@ test output fragment not combined with fixture (positive) [[
   i int
 ]] transform "Print id" to [[CREATE TABLE T(i int);]]
 
+test allow newlines in ATerm strings (positive) [[
+  i int
+]] transform "Newline String" to "<newline>
+</newline>"
+
 


### PR DESCRIPTION
ATerm strings can now have newlines.

This is allowed in Stratego:
```
my-transformation:
(node,_,_,_) -> (filename, "<newline>
</newline>")
```

So now this is also allowed in SPT:
```
test allow newlines in ATerm strings (positive) [[
  i int
]] transform "my-transformation" to "<newline>
</newline>"
```