### PR TITLE
Update the SPT testrunner in Eclipse.

### DIFF
--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
@@ -33,16 +33,19 @@ public class AnalyzeExpectationEvaluator implements ISpoofaxExpectationEvaluator
 
     private static final ILogger logger = LoggerUtils.logger(AnalyzeExpectationEvaluator.class);
 
-    @Override public Collection<Integer> usesSelections(IFragment fragment, AnalysisMessageExpectation expectation) {
+    @Override
+    public Collection<Integer> usesSelections(IFragment fragment, AnalysisMessageExpectation expectation) {
         return Lists.newArrayList(expectation.selections());
     }
 
-    @Override public TestPhase getPhase(IContext unused, AnalysisMessageExpectation expectation) {
+    @Override
+    public TestPhase getPhase(IContext unused, AnalysisMessageExpectation expectation) {
         return TestPhase.ANALYSIS;
     }
 
-    @Override public ISpoofaxTestExpectationOutput evaluate(
-        ITestExpectationInput<ISpoofaxParseUnit, ISpoofaxAnalyzeUnit> input, AnalysisMessageExpectation expectation) {
+    @Override
+    public ISpoofaxTestExpectationOutput evaluate(ITestExpectationInput<ISpoofaxParseUnit, ISpoofaxAnalyzeUnit> input,
+        AnalysisMessageExpectation expectation) {
         List<IMessage> messages = Lists.newLinkedList();
         // analysis expectations don't have output fragments (not at the moment anyway)
         final Iterable<ISpoofaxFragmentResult> fragmentResults = Iterables2.empty();
@@ -115,13 +118,10 @@ public class AnalyzeExpectationEvaluator implements ISpoofaxExpectationEvaluator
                 numOk = false;
         }
         if(!numOk) {
-            messages
-                .add(
-                    MessageFactory
-                        .newAnalysisError(
-                            test.getResource(), test.getDescriptionRegion(), "Expected " + errorStr(operation) + " "
-                                + expectedNumMessages + " " + severity + "s, but got " + interestingMessages.size(),
-                            null));
+            messages.add(MessageFactory.newAnalysisError(test.getResource(), test.getDescriptionRegion(),
+                "Expected " + errorStr(operation) + " " + expectedNumMessages + " " + severity + "s, but got "
+                    + interestingMessages.size(),
+                null));
         }
 
         // Check message locations
@@ -180,17 +180,17 @@ public class AnalyzeExpectationEvaluator implements ISpoofaxExpectationEvaluator
             } else {
                 // check only the selected message
                 if(!lastSelectedMsg.message().contains(content)) {
-                    logger.warn("Not equal: ");
+                    logger.debug("Not equal: ");
                     String s = "";
                     for(byte b : content.getBytes()) {
                         s = (s.equals("") ? Byte.toString(b) : s + ", " + b);
                     }
-                    logger.warn("Content: {}", s);
+                    logger.debug("Content: {}", s);
                     s = "";
                     for(byte b : lastSelectedMsg.message().getBytes()) {
                         s = (s.equals("") ? Byte.toString(b) : s + ", " + b);
                     }
-                    logger.warn("Message: {}", s);
+                    logger.debug("Message: {}", s);
                     messages
                         .add(MessageFactory.newAnalysisError(test.getResource(), test.getDescriptionRegion(),
                             String.format("Expected a %s containing the text \"%s\", but found one with text \"%s\".",

--- a/org.metaborg.spt.test/parse/parse-no-fixture.spt
+++ b/org.metaborg.spt.test/parse/parse-no-fixture.spt
@@ -1,0 +1,20 @@
+module parse-no-fixture
+language SPT-Interactive
+
+fixture [[[
+  module parse-no-fixture
+  language MiniSQL
+  [[[...]]]
+]]]
+
+test parse to outer AST (positive) [[[
+  test parse to outer AST (positive) [[
+    CREATE TABLE T();
+  ]] parse to Module([TableDef("T", [])])
+]]] analysis succeeds
+
+test parse to inner AST (negative) [[[
+  test parse to inner AST (negative) [[
+    CREATE TABLE T();
+  ]] parse to TableDef("T", [])
+]]] analysis fails

--- a/org.metaborg.spt.test/regressions/parser.spt
+++ b/org.metaborg.spt.test/regressions/parser.spt
@@ -1,0 +1,7 @@
+module parserregressions
+language MiniSQL
+
+start symbol ID
+
+// https://github.com/metaborg/jsglr/pull/4
+test repeated parsing of the final character of a string [[a/]] parse fails

--- a/org.metaborg.spt.testrunner.eclipse/plugin.xml
+++ b/org.metaborg.spt.testrunner.eclipse/plugin.xml
@@ -9,24 +9,66 @@
             name="SPT Test Runner">
       </view>
    </extension>
+   
+   <!-- Menu bar entry to run the currently open SPT file -->
    <extension
          point="org.eclipse.ui.menus">
       <menuContribution
             allPopups="true"
-            locationURI="popup:org.metaborg.spoofax.eclipse.menu.project?after=additions">
+            locationURI="menu:org.metaborg.spoofax.eclipse.meta.menu.main?after=additions">
          <command
-               commandId="org.metaborg.spt.testrunner.eclipse.command.runall"
-               label="Run All SPT Tests"
+               commandId="org.metaborg.spt.testrunner.eclipse.command.runone"
+               label="Run tests of SPT file"
                style="push">
          </command>
       </menuContribution>
    </extension>
+   
+   <!-- Menu bar entry to run all the SPT tests inside a selected directory or file -->
+   <extension
+         point="org.eclipse.ui.menus">
+      <menuContribution
+            allPopups="true"
+            locationURI="menu:org.metaborg.spoofax.eclipse.meta.menu.main?after=additions">
+         <command
+               commandId="org.metaborg.spt.testrunner.eclipse.command.runall"
+               label="Run all selected tests"
+               style="push">
+         </command>
+      </menuContribution>
+   </extension>
+   
+   <!-- Project context menu entry to run all tests in the project -->
+   <extension
+         point="org.eclipse.ui.menus">
+      <menuContribution
+            allPopups="true"
+            locationURI="popup:org.metaborg.spoofax.eclipse.meta.menu.project?after=additions">
+         <command
+               commandId="org.metaborg.spt.testrunner.eclipse.command.runall"
+               label="Run all SPT tests"
+               style="push">
+         </command>
+      </menuContribution>
+   </extension>
+   
+   <!-- Command to run all spt files in a selection -->
    <extension
          point="org.eclipse.ui.commands">
       <command
             defaultHandler="org.metaborg.spt.testrunner.eclipse.RunAllHandler"
             id="org.metaborg.spt.testrunner.eclipse.command.runall"
             name="Run All SPT Tests">
+      </command>
+   </extension>
+   
+   <!-- Command to run a single spt file that is open in the editor -->
+   <extension
+         point="org.eclipse.ui.commands">
+      <command
+            defaultHandler="org.metaborg.spt.testrunner.eclipse.RunOneHandler"
+            id="org.metaborg.spt.testrunner.eclipse.command.runone"
+            name="Run One SPT Test">
       </command>
    </extension>
 </plugin>

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/Activator.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/Activator.java
@@ -72,6 +72,10 @@ public class Activator extends AbstractUIPlugin {
         plugin.getLog().log(new Status(IStatus.ERROR, PLUGIN_ID, message));
     }
 
+    public static void logWarn(String message) {
+        plugin.getLog().log(new Status(IStatus.WARNING, PLUGIN_ID, message));
+    }
+
     public static void logInfo(String message) {
         plugin.getLog().log(new Status(IStatus.INFO, PLUGIN_ID, message));
     }

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/RunAllHandler.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/RunAllHandler.java
@@ -1,13 +1,13 @@
 package org.metaborg.spt.testrunner.eclipse;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.vfs2.FileObject;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -18,9 +18,12 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.ui.handlers.HandlerUtil;
+import org.metaborg.spoofax.eclipse.SpoofaxPlugin;
+import org.metaborg.spoofax.eclipse.resource.IEclipseResourceService;
 
 /**
- * The handler for the 'Run All SPT tests' command that is executed from a project's Spoofax context menu.
+ * The handler for the 'Run All SPT tests' command that is executed from a project's Spoofax (meta) context menu. Or
+ * from the Spoofax (meta) menu bar entry.
  */
 public class RunAllHandler extends AbstractHandler {
     protected static TestRunner runner = null;
@@ -30,55 +33,78 @@ public class RunAllHandler extends AbstractHandler {
             runner = new TestRunner();
         }
 
+        // will contain all selected locations from which we should collect tests
+        final List<FileObject> testLocations = new ArrayList<>();
+
         final ISelection sel = HandlerUtil.getCurrentSelectionChecked(event);
+        // the package explorer returns a tree selection
         if(sel instanceof ITreeSelection) {
+            // we need this to resolve to VFS files that Spoofax can handle
+            final IEclipseResourceService resolver =
+                SpoofaxPlugin.injector().getInstance(IEclipseResourceService.class);
+
             final ITreeSelection tree = (ITreeSelection) sel;
-            final List<URI> testLocations = new ArrayList<>();
             for(TreePath p : tree.getPaths()) {
-                for(int i = 0; i < p.getSegmentCount(); i++) {
-                    final Object seg = p.getSegment(i);
-                    if(seg instanceof IContainer) {
-                        final IContainer c = (IContainer) seg;
-                        final URI uri = c.getLocationURI();
-                        testLocations.add(uri);
-                    } else if(seg instanceof IJavaProject) {
-                        final IContainer c = ((IJavaProject) seg).getProject();
-                        final URI uri = c.getLocationURI();
-                        testLocations.add(uri);
+                // get the last segment of the selection (i.e. we only care about the actually selected element)
+                final Object selectedObject = p.getLastSegment();
+                final IResource resource;
+
+                if(selectedObject instanceof IResource) {
+                    // IFiles and (non-java) IProjects are IResources
+                    resource = (IResource) selectedObject;
+                } else if(selectedObject instanceof IJavaProject) {
+                    // for Java projects we need to be more creative
+                    resource = ((IJavaProject) selectedObject).getProject();
+                } else {
+                    resource = null;
+                    Activator.logWarn("SPT Run can't handle a selection of type " + selectedObject.getClass()
+                        + ". Object: " + selectedObject);
+                }
+                if(resource != null) {
+                    final FileObject file = resolver.resolve(resource);
+                    if(file != null) {
+                        testLocations.add(file);
                     } else {
-                        Activator.logError("SPT Run can't handle a selection of type " + p.getSegment(i).getClass());
+                        // just skip it
+                        Activator.logWarn("SPT could not resolve the selected resource " + resource.getName());
                     }
                 }
             }
-            if(testLocations.isEmpty()) {
-                Activator.logError("SPT Run had no locations to execute on.");
-            }
 
+        } else {
+            Activator.logError(
+                "SPT could not find a selected project, directory, or file to run tests from. Instead, we got " + sel);
+        }
+
+        if(!testLocations.isEmpty()) {
+            // run all tests of these locations
             RunTestsJob job = new RunTestsJob(testLocations);
             job.setRule(ResourcesPlugin.getWorkspace().getRoot());
             job.schedule();
-
         } else {
-            Activator.logError("SPT Run can't handle a selection of type " + sel.getClass());
+            // If we have no location to run on (i.e. selected projects) and no input to run on (i.e. open file in
+            // editor) we don't know what to do
+            Activator.logError("SPT Run had no locations to execute on.");
         }
+
         return null;
     }
 
     private class RunTestsJob extends Job {
 
-        private final List<URI> testLocations;
+        private final List<FileObject> testLocations;
 
-        public RunTestsJob(List<URI> testLocations) {
+        public RunTestsJob(List<FileObject> testLocations) {
             super(RunTestsJob.class.getSimpleName());
             this.testLocations = testLocations;
         }
 
         @Override protected IStatus run(IProgressMonitor monitor) {
-            for(URI uri : testLocations) {
-                runner.runAll(uri);
-            }
+            runner.runAll(testLocations.toArray(new FileObject[testLocations.size()]));
             return Status.OK_STATUS;
         }
-
     }
+
+
+
 }

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/RunOneHandler.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/RunOneHandler.java
@@ -1,0 +1,70 @@
+package org.metaborg.spt.testrunner.eclipse;
+
+import org.apache.commons.vfs2.FileObject;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.metaborg.spoofax.eclipse.SpoofaxPlugin;
+import org.metaborg.spoofax.eclipse.resource.IEclipseResourceService;
+
+public class RunOneHandler extends AbstractHandler {
+
+    protected static TestRunner runner = null;
+
+    @Override public Object execute(ExecutionEvent event) throws ExecutionException {
+        if(runner == null) {
+            runner = new TestRunner();
+        }
+
+        // get the file that is open in the editor
+        // may be null
+        final IEditorInput editorInput = HandlerUtil.getActiveEditorInput(event);
+        if(editorInput == null) {
+            Activator.logError("SPT could not find an open file to run tests from.");
+            return null;
+        }
+        // may be null
+        final FileObject file =
+            SpoofaxPlugin.injector().getInstance(IEclipseResourceService.class).resolve(editorInput);
+        if(file == null) {
+            Activator.logError("SPT could not resolve the open file to a VFS file to run tests from.");
+            return null;
+        }
+        if(!TestRunner.SPT_EXT.equals(file.getName().getExtension())) {
+            Activator.logError("SPT can't run tests from the file: " + file.getName() + ". It's not an SPT file.");
+            return null;
+        }
+
+        // run the tests of this file
+        RunTestFileJob job = new RunTestFileJob(file);
+        job.setRule(ResourcesPlugin.getWorkspace().getRoot());
+        job.schedule();
+
+        return null;
+    }
+
+    /**
+     * A job to run the tests of a given file.
+     */
+    private class RunTestFileJob extends Job {
+
+        private final FileObject file;
+
+        public RunTestFileJob(FileObject file) {
+            super(RunTestFileJob.class.getSimpleName());
+            this.file = file;
+        }
+
+        @Override protected IStatus run(IProgressMonitor monitor) {
+            runner.runAll(file);
+            return Status.OK_STATUS;
+        }
+    }
+}

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/TestRunLabelProvider.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/TestRunLabelProvider.java
@@ -37,7 +37,16 @@ public class TestRunLabelProvider extends LabelProvider
     }
 
     @Override public Color getForeground(Object element, int columnIndex) {
-        if(element instanceof TestCaseRun) {
+        if(element instanceof TestSuiteRun) {
+            TestSuiteRun tsr = (TestSuiteRun) element;
+            if(tsr.ext != null && tsr.ext.isSuccessful()) {
+                // use default color;
+                return null;
+            } else {
+                // use red
+                return new Color(Display.getCurrent(), 159, 63, 63);
+            }
+        } else if(element instanceof TestCaseRun) {
             TestCaseRun tcr = (TestCaseRun) element;
             if(tcr.result() != null) {
                 return tcr.result().isSuccessful() ? new Color(Display.getCurrent(), 10, 100, 10)

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/TestRunViewPart.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/TestRunViewPart.java
@@ -1,5 +1,8 @@
 package org.metaborg.spt.testrunner.eclipse;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.apache.commons.vfs2.FileObject;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -9,16 +12,26 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeSelection;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.jface.viewers.ViewerSorter;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.events.ControlEvent;
+import org.eclipse.swt.events.ControlListener;
+import org.eclipse.swt.events.TreeEvent;
+import org.eclipse.swt.events.TreeListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.ui.IEditorPart;
@@ -29,6 +42,7 @@ import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.texteditor.ITextEditor;
+import org.metaborg.core.messages.IMessage;
 import org.metaborg.spoofax.core.Spoofax;
 import org.metaborg.spoofax.eclipse.SpoofaxPlugin;
 import org.metaborg.spoofax.eclipse.resource.IEclipseResourceService;
@@ -56,8 +70,15 @@ public class TestRunViewPart extends ViewPart {
     private final FormToolkit toolkit = new FormToolkit(Display.getCurrent());
     private Label lblRatio;
     private final static int LBLRATIO_WIDTHHINT = 65;
+    private final static int TREE_MINWIDTH = 100;
+    private final static int CONS_MINWIDTH = 100;
+    private final static int SASH_WIDTH = 5;
     private JUnitProgressBar pb;
+    private Composite parent;
+    private Composite top;
     private TreeViewer treeViewer;
+    private SashForm sashForm;
+    private Text cons;
     private Action onlyFailedTestsAction;
     private ViewerFilter failedTestsFilter;
 
@@ -70,84 +91,105 @@ public class TestRunViewPart extends ViewPart {
      * 
      * @param parent
      */
-    @Override public void createPartControl(Composite parent) {
+    @Override public void createPartControl(Composite prnt) {
+        this.parent = prnt;
         GridData gd = null;
 
-        GridLayout layout = new GridLayout(3, false);
+        GridLayout layout = new GridLayout(1, false);
         parent.setLayout(layout);
+        top = new Composite(parent, SWT.NONE);
+        gd = new GridData();
+        gd.horizontalAlignment = SWT.FILL;
+        gd.verticalAlignment = SWT.TOP;
+        gd.grabExcessHorizontalSpace = true;
+        top.setLayoutData(gd);
 
-        pb = new JUnitProgressBar(parent);
+        layout = new GridLayout(3, false);
+        top.setLayout(layout);
+
+        pb = new JUnitProgressBar(top);
         gd = new GridData();
         gd.horizontalAlignment = SWT.FILL;
         gd.grabExcessHorizontalSpace = true;
         gd.verticalAlignment = SWT.TOP;
         pb.setLayoutData(gd);
 
-        Label lblTests = new Label(parent, SWT.NONE);
+        Label lblTests = new Label(top, SWT.NONE);
         lblTests.setText("Tests");
         gd = new GridData();
         gd.horizontalAlignment = SWT.BEGINNING;
         lblTests.setLayoutData(gd);
 
-        lblRatio = new Label(parent, SWT.RIGHT);
+        lblRatio = new Label(top, SWT.RIGHT);
         gd = new GridData();
         gd.horizontalAlignment = SWT.END;
         gd.widthHint = LBLRATIO_WIDTHHINT;
         lblRatio.setLayoutData(gd);
 
-        treeViewer = new TreeViewer(parent, SWT.BORDER);
-        Tree tv = treeViewer.getTree();
+        // bottom = new Composite(parent, SWT.NONE);
+        // bottom.setBackground(new Color(Display.getCurrent(), 100, 0, 0));
+        sashForm = new SashForm(parent, SWT.HORIZONTAL);
+        sashForm.setSashWidth(SASH_WIDTH);
         gd = new GridData();
+        gd.horizontalAlignment = SWT.FILL;
+        gd.verticalAlignment = SWT.FILL;
         gd.grabExcessHorizontalSpace = true;
+        gd.grabExcessVerticalSpace = true;
+        gd.horizontalSpan = 3;
+        // bottom.setLayoutData(gd);
+        sashForm.setLayoutData(gd);
+        layout = new GridLayout(2, false);
+        // bottom.setLayout(layout);
+        sashForm.setLayout(layout);
+
+        treeViewer = new TreeViewer(sashForm, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+        final Tree tree = treeViewer.getTree();
+        gd = new GridData();
+        // gd.grabExcessHorizontalSpace = true;
         gd.grabExcessVerticalSpace = true;
         gd.horizontalAlignment = SWT.FILL;
         gd.verticalAlignment = SWT.FILL;
-        gd.horizontalSpan = 3;
-        tv.setLayoutData(gd);
+        gd.minimumWidth = TREE_MINWIDTH;
+        tree.setLayoutData(gd);
 
         TreeColumn column = new TreeColumn(treeViewer.getTree(), SWT.NONE);
-
         column.setText("");
         column.pack();
 
         treeViewer.setContentProvider(new TestRunContentProvider());
         treeViewer.setLabelProvider(new TestRunLabelProvider());
         treeViewer.setSorter(new ViewerSorter());
-        treeViewer.addDoubleClickListener(new IDoubleClickListener() {
+        treeViewer.addDoubleClickListener(new JumpToFileListener());
+        treeViewer.addSelectionChangedListener(new UpdateConsoleListener());
+        tree.addControlListener(new ControlListener() {
 
-            public void doubleClick(DoubleClickEvent event) {
-                Object selectObject = ((IStructuredSelection) treeViewer.getSelection()).getFirstElement();
+            @Override public void controlResized(ControlEvent e) {
+                packColumns();
+            }
 
-                FileObject file = null;
-                int offset = 0;
-
-                if(selectObject instanceof TestCaseRun) {
-                    TestCaseRun tcr = (TestCaseRun) selectObject;
-                    file = tcr.test.getResource();
-                    offset = tcr.test.getDescriptionRegion().startOffset();
-                } else if(selectObject instanceof TestSuiteRun) {
-                    TestSuiteRun tsr = ((TestSuiteRun) selectObject);
-                    file = tsr.file;
-                }
-
-                if(file != null) {
-                    // GROSS!
-                    final Spoofax spoofax = SpoofaxPlugin.spoofax();
-                    IEclipseResourceService r = spoofax.injector.getInstance(IEclipseResourceService.class);
-                    IPath p = r.unresolve(file).getFullPath();
-                    IFile f = ResourcesPlugin.getWorkspace().getRoot().getFile(p);
-                    IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-                    try {
-                        IEditorPart ep = IDE.openEditor(page, f);
-                        if(ep instanceof ITextEditor) {
-                            ((ITextEditor) ep).selectAndReveal(offset, 0);
-                        }
-                    } catch(PartInitException e) {
-                        // whatever
-                    }
-                }
+            @Override public void controlMoved(ControlEvent e) {
             }
         });
+        tree.addTreeListener(new TreeListener() {
+
+            @Override public void treeExpanded(TreeEvent e) {
+                packColumns();
+            }
+
+            @Override public void treeCollapsed(TreeEvent e) {
+            }
+        });
+
+        cons = new Text(sashForm, SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+        gd = new GridData();
+        gd.grabExcessHorizontalSpace = true;
+        gd.grabExcessVerticalSpace = true;
+        gd.horizontalAlignment = SWT.FILL;
+        gd.verticalAlignment = SWT.FILL;
+        gd.minimumWidth = CONS_MINWIDTH;
+        cons.setLayoutData(gd);
+
+        sashForm.setWeights(new int[] { 40, 60 });
 
         createActions();
         createFilters();
@@ -163,12 +205,23 @@ public class TestRunViewPart extends ViewPart {
 
     }
 
+    private void packColumns() {
+        final Tree tree = treeViewer.getTree();
+        Display.getDefault().asyncExec(new Runnable() {
+            public void run() {
+                for(TreeColumn c : tree.getColumns()) {
+                    c.pack();
+                }
+            }
+        });
+    }
+
     private void updateHeader() {
         int nrTests = run.numTests();
         if(nrTests == 0) {
             lblRatio.setText("0 / 0");
         } else {
-            lblRatio.setText(String.format("%d / %d    ", (nrTests - nrFailedTests), nrTests));
+            lblRatio.setText(String.format("%d / %d    ", run.numPassed(), nrTests));
         }
         pb.setMaximum(nrTests);
     }
@@ -221,18 +274,10 @@ public class TestRunViewPart extends ViewPart {
 
     private void refresh() {
         updateHeader();
-        treeViewer.refresh();
-        pb.redraw();
         treeViewer.expandAll();
-
-        final Tree tree = treeViewer.getTree();
-        Display.getCurrent().asyncExec(new Runnable() {
-            public void run() {
-                for(TreeColumn tc : tree.getColumns()) {
-                    tc.pack();
-                }
-            }
-        });
+        pb.redraw();
+        treeViewer.refresh();
+        packColumns();
     }
 
     public void setData(MultiTestSuiteRun run) {
@@ -262,5 +307,114 @@ public class TestRunViewPart extends ViewPart {
         refreshDisabled = b;
         if(!b)
             refresh();
+    }
+
+    /**
+     * A listener that (on a double click event) tries to open the file corresponding to the clicked TestCaseRun or
+     * TestSuiteRun.
+     */
+    private class JumpToFileListener implements IDoubleClickListener {
+
+        public void doubleClick(DoubleClickEvent event) {
+            Object selectObject = ((IStructuredSelection) treeViewer.getSelection()).getFirstElement();
+
+            FileObject file = null;
+            int offset = 0;
+
+            if(selectObject instanceof TestCaseRun) {
+                TestCaseRun tcr = (TestCaseRun) selectObject;
+                file = tcr.test.getResource();
+                offset = tcr.test.getDescriptionRegion().startOffset();
+            } else if(selectObject instanceof TestSuiteRun) {
+                TestSuiteRun tsr = ((TestSuiteRun) selectObject);
+                file = tsr.file;
+            }
+
+            if(file != null) {
+                // GROSS!
+                final Spoofax spoofax = SpoofaxPlugin.spoofax();
+                IEclipseResourceService r = spoofax.injector.getInstance(IEclipseResourceService.class);
+                IPath p = r.unresolve(file).getFullPath();
+                IFile f = ResourcesPlugin.getWorkspace().getRoot().getFile(p);
+                IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+                try {
+                    IEditorPart ep = IDE.openEditor(page, f);
+                    if(ep instanceof ITextEditor) {
+                        ((ITextEditor) ep).selectAndReveal(offset, 0);
+                    }
+                } catch(PartInitException e) {
+                    // whatever
+                }
+            }
+        }
+    }
+
+    /**
+     * Listener that updates the console part if a TestCaseRun or TestSuiteRun is selected.
+     */
+    private class UpdateConsoleListener implements ISelectionChangedListener {
+
+        @Override public void selectionChanged(SelectionChangedEvent event) {
+            final ISelection generalSel = event.getSelection();
+            if(generalSel.isEmpty()) {
+                cons.setText("");
+                return;
+            }
+            if(generalSel instanceof ITreeSelection) {
+                final Object selObj = ((ITreeSelection) generalSel).getFirstElement();
+                if(selObj instanceof TestSuiteRun) {
+                    final TestSuiteRun tsr = (TestSuiteRun) selObj;
+                    if(tsr.ext == null) {
+                        cons.setText("Failed to load the contents of this test suite due to an IO error.");
+                    } else if(tsr.ext.isSuccessful()) {
+                        cons.setText("");
+                    } else {
+                        final StringWriter strW = new StringWriter();
+                        final PrintWriter pw = new PrintWriter(strW);
+                        pw.print("Failed to extract test cases from this test suite:\n");
+                        for(IMessage m : tsr.ext.getAllMessages()) {
+                            printMessage(m, pw);
+                            pw.println();
+                        }
+                        pw.flush();
+                        pw.close();
+                        cons.setText(strW.toString());
+                    }
+                } else if(selObj instanceof TestCaseRun) {
+                    final TestCaseRun tcr = (TestCaseRun) selObj;
+                    if(tcr.result() == null) {
+                        cons.setText(
+                            "This test case has not yet been executed.\nPlease select it again when it's done.");
+                    } else if(tcr.result().isSuccessful()) {
+                        cons.setText("");
+                    } else {
+                        final StringWriter sw = new StringWriter();
+                        final PrintWriter pw = new PrintWriter(sw);
+                        pw.println("This test cased failed:");
+                        for(IMessage m : tcr.result().getAllMessages()) {
+                            printMessage(m, pw);
+                            pw.println();
+                        }
+                        pw.flush();
+                        pw.close();
+                        cons.setText(sw.toString());
+                    }
+                }
+            }
+            return;
+        }
+
+        private void printMessage(IMessage m, PrintWriter pw) {
+            pw.print(m.severity());
+            if(m.region() != null) {
+                pw.append(" @ (").append(Integer.toString(m.region().startOffset())).append(", ")
+                    .append(Integer.toString(m.region().endOffset())).append(")");
+            }
+            pw.append(" : ").append(m.message());
+            if(m.exception() != null) {
+                pw.println();
+                m.exception().printStackTrace(pw);
+            }
+        }
     }
 }

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/TestRunner.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/TestRunner.java
@@ -2,9 +2,8 @@ package org.metaborg.spt.testrunner.eclipse;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.FileObject;
@@ -18,7 +17,6 @@ import org.metaborg.core.language.ILanguageService;
 import org.metaborg.core.messages.IMessage;
 import org.metaborg.core.project.IProject;
 import org.metaborg.core.project.IProjectService;
-import org.metaborg.core.resource.IResourceService;
 import org.metaborg.mbt.core.model.ITestCase;
 import org.metaborg.spoofax.core.Spoofax;
 import org.metaborg.spoofax.core.syntax.JSGLRParserConfiguration;
@@ -46,24 +44,17 @@ import com.google.inject.Injector;
  */
 public class TestRunner {
 
+    public static final String SPT_EXT = "spt";
+
     private static final ILogger logger = LoggerUtils.logger(TestRunner.class);
 
     /**
-     * See {@link #runAll(FileObject)}.
-     */
-    public void runAll(URI uri) {
-        final Spoofax spoofax = SpoofaxPlugin.spoofax();
-        final IResourceService resService = spoofax.resourceService;
-        final FileObject fob = resService.resolve(uri);
-        runAll(fob);
-    }
-
-    /**
-     * Runs all tests under the given path.
+     * Runs all tests collected for the given FileObjects.
      * 
-     * NOTE: for now it only works on projects, but this might be extended later to also support any directory or file.
+     * It uses {@link FileObject#findFiles(org.apache.commons.vfs2.FileSelector)} to get all SPT files if the given
+     * FileObject isn't a file.
      */
-    public void runAll(FileObject parentDirOrFile) {
+    public void runAll(FileObject... fobs) {
         final Spoofax spoofax = SpoofaxPlugin.spoofax();
         final ILanguageService langService = spoofax.languageService;
         final ISpoofaxInputUnitService inputService = spoofax.injector.getInstance(ISpoofaxInputUnitService.class);
@@ -77,88 +68,106 @@ public class TestRunner {
         final ILanguage sptLang = langService.getLanguage("SPT");
         final ILanguageImpl spt = sptLang == null ? null : sptLang.activeImpl();
         if(spt == null) {
-            logger.warn("Unable to obtain SPT for running tests at: {}. {}", parentDirOrFile, sptLang);
+            logger.warn("Unable to obtain SPT for running tests");
             return;
         }
 
-        // get the project
-        final IProject project = projectService.get(parentDirOrFile);
-        if(project == null) {
-            logger.warn("Unable to obtain the project: {}", parentDirOrFile);
-            return;
-        }
-
-        // collect all test suites
-        FileObject[] allSuites = null;
-        try {
-            allSuites = parentDirOrFile.findFiles(FileSelectorUtils.extension("spt"));
-        } catch(FileSystemException e1) {
-            logger.warn("Couldn't get the test suites of project {}", e1, parentDirOrFile);
-            return;
-        }
-
-        // collect all tests by their suites
-        final Map<FileObject, ISpoofaxTestCaseExtractionResult> extractionMap = new HashMap<>();
-        for(FileObject testSuite : allSuites) {
-            final String text;
-            try(InputStream in = testSuite.getContent().getInputStream()) {
-                text = IOUtils.toString(in, (String) null);
-            } catch(IOException e) {
-                logger.error("Unable to process file {}", e, testSuite);
-                continue;
+        // get the projects
+        final IProject[] projects = new IProject[fobs.length];
+        for(int i = 0; i < fobs.length; i++) {
+            final FileObject fob = fobs[i];
+            final IProject project = projectService.get(fob);
+            if(project != null) {
+                projects[i] = project;
+            } else {
+                logger.warn("Unable to obtain the project for: {}", fob);
+                return;
             }
-            final ISpoofaxInputUnit input = inputService.inputUnit(testSuite, text, spt, null);
-            final ISpoofaxTestCaseExtractionResult extractionResult = extractor.extract(input, project);
-            extractionMap.put(testSuite, extractionResult);
         }
-        logger.debug("Extracted all tests");
+
+        // collect all test suites for each given FileObject
+        final List<List<FileObject>> allSuites = new ArrayList<>();
+        for(FileObject fob : fobs) {
+            final List<FileObject> suites = new ArrayList<>();
+            allSuites.add(suites);
+            try {
+                if(fob.isFile()) {
+                    suites.add(fob);
+                } else {
+                    for(FileObject suite : fob.findFiles(FileSelectorUtils.extension(SPT_EXT))) {
+                        suites.add(suite);
+                    }
+                }
+            } catch(FileSystemException e1) {
+                logger.warn("Couldn't get the test suites of project {}", e1, fob);
+                return;
+            }
+        }
 
         // get the testrunner view and prepare for this test run
         resetView();
 
-        // fill in the data model for this test run
+        // create the data model for this test run
         final MultiTestSuiteRun run = new MultiTestSuiteRun();
-        final Map<FileObject, TestSuiteRun> suiteRuns = new HashMap<>();
-        final Map<ITestCase, TestCaseRun> caseRuns = new HashMap<>();
-        for(FileObject suite : allSuites) {
-            final ISpoofaxTestCaseExtractionResult ext = extractionMap.get(suite);
-            final String suiteName = ext.getName();
-            if(ext.isSuccessful()) {
-                final TestSuiteRun tsr = new TestSuiteRun(suite, run, suiteName);
-                suiteRuns.put(suite, tsr);
+
+        // start adding the test suites that we found to the object model
+        for(int i = 0; i < allSuites.size(); i++) {
+            final List<FileObject> suites = allSuites.get(i);
+            final IProject project = projects[i];
+            for(FileObject suite : suites) {
+                // may be null
+                final ISpoofaxTestCaseExtractionResult ext = extractSuite(suite, project, spt, inputService, extractor);
+                final TestSuiteRun tsr;
+                if(ext == null) {
+                    // record the failed extraction
+                    logger.error("Test suite {} failed to extract properly.", suite.getName());
+                    tsr = new TestSuiteRun(ext, project, suite, run, suite.getName().getBaseName());
+                } else {
+                    if(ext.isSuccessful()) {
+                        // the test suite was properly extracted
+                        tsr = new TestSuiteRun(ext, project, suite, run, ext.getName());
+                    } else {
+                        // record the failed extraction
+                        logger.error("Test suite {} failed to extract properly.", suite.getName());
+                        for(IMessage m : ext.getAllMessages()) {
+                            logger.error("[{}] :: ({},{}) :: {}", m.severity(),
+                                m.region() == null ? null : m.region().startOffset(),
+                                m.region() == null ? null : m.region().endOffset(), m.message());
+                        }
+                        tsr = new TestSuiteRun(ext, project, suite, run, suite.getName().getBaseName());
+                    }
+                }
                 run.suites.add(tsr);
-                for(ITestCase test : ext.getTests()) {
-                    final TestCaseRun tcr = new TestCaseRun(tsr, test);
-                    caseRuns.put(test, tcr);
+
+                // get and add the test cases to the suite
+                if(ext != null && ext.isSuccessful()) {
+                    for(ITestCase test : ext.getTests()) {
+                        final TestCaseRun tcr = new TestCaseRun(tsr, test);
+                        tsr.tests.add(tcr);
+                    }
                 }
-            } else {
-                // TODO what do we want to do in this case?
-                logger.error("Test suite {} failed to extract properly.", ext.getName());
-                for(IMessage m : ext.getAllMessages()) {
-                    logger.error("[{}] :: ({},{}) :: {}", m.severity(),
-                        m.region() == null ? null : m.region().startOffset(),
-                        m.region() == null ? null : m.region().endOffset(), m.message());
-                }
+
+                // load the data in the view
+                setData(run);
             }
         }
 
-        // load the data in the view
-        setData(run);
         logger.debug("Loaded all tests into the view Java model");
 
         // run the tests
-        for(FileObject suite : allSuites) {
-            final ISpoofaxTestCaseExtractionResult ext = extractionMap.get(suite);
-            if(ext.isSuccessful()) {
+        for(TestSuiteRun tsr : run.suites) {
+            // may be null
+            final ISpoofaxTestCaseExtractionResult ext = tsr.ext;
+            if(ext != null && ext.isSuccessful()) {
                 // get lut for the test suite
                 final String lutStr = ext.getLanguage();
                 if(lutStr == null) {
-                    logger.warn("Can't execute tests of suite {}, as there is no language header.", suite);
+                    logger.warn("Can't execute tests of suite {}, as there is no language header.", tsr.name);
                     continue;
                 }
                 final ILanguage lutLang = langService.getLanguage(lutStr);
                 if(lutLang == null) {
-                    logger.warn("Can't execute tests of suite {}, as the language {} couldn't be loaded.", suite,
+                    logger.warn("Can't execute tests of suite {}, as the language {} couldn't be loaded.", tsr.name,
                         lutStr);
                     continue;
                 }
@@ -175,10 +184,10 @@ public class TestRunner {
                 }
 
                 // run the test cases
-                for(ITestCase test : ext.getTests()) {
-                    final TestCaseRun tcr = caseRuns.get(test);
+                final IProject project = tsr.project;
+                for(TestCaseRun tcr : tsr.tests) {
                     tcr.start();
-                    final ISpoofaxTestResult result = runner.run(project, test, lut, null, cfg);
+                    final ISpoofaxTestResult result = runner.run(project, tcr.test, lut, null, cfg);
                     finish(tcr, result);
                 }
             }
@@ -186,6 +195,19 @@ public class TestRunner {
 
     }
 
+    private ISpoofaxTestCaseExtractionResult extractSuite(FileObject testSuite, IProject project, ILanguageImpl spt,
+        ISpoofaxInputUnitService inputService, ISpoofaxTestCaseExtractor extractor) {
+        final String text;
+        try(InputStream in = testSuite.getContent().getInputStream()) {
+            text = IOUtils.toString(in, (String) null);
+        } catch(IOException e) {
+            logger.error("Unable to process file {}", e, testSuite);
+            return null;
+        }
+        final ISpoofaxInputUnit input = inputService.inputUnit(testSuite, text, spt, null);
+        final ISpoofaxTestCaseExtractionResult extractionResult = extractor.extract(input, project);
+        return extractionResult;
+    }
 
     private TestRunViewPart getViewPart() {
         try {

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/model/MultiTestSuiteRun.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/model/MultiTestSuiteRun.java
@@ -11,6 +11,7 @@ public class MultiTestSuiteRun {
     public final List<TestSuiteRun> suites = new ArrayList<>();
 
     private int numFailed = 0;
+    private int numPassed = 0;
 
     /**
      * The number of test cases that failed.
@@ -22,10 +23,26 @@ public class MultiTestSuiteRun {
     }
 
     /**
+     * The number of test cases that passed.
+     * 
+     * Accumulated over all our test suites.
+     */
+    public int numPassed() {
+        return numPassed;
+    }
+
+    /**
      * Our children should notify whenever they have a failing test case run
      */
     protected void fail() {
         numFailed++;
+    }
+
+    /**
+     * Our children should notify whenever they have a passing test case run
+     */
+    protected void pass() {
+        numPassed++;
     }
 
     /**

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/model/TestCaseRun.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/model/TestCaseRun.java
@@ -32,7 +32,6 @@ public class TestCaseRun {
         this.parent = parent;
         this.test = test;
         this.start = System.currentTimeMillis();
-        parent.tests.add(this);
     }
 
     /**
@@ -55,6 +54,13 @@ public class TestCaseRun {
     public void finish(ISpoofaxTestResult res) {
         this.duration = System.currentTimeMillis() - start;
         this.res = res;
+        if(parent != null && res != null) {
+            if(res.isSuccessful()) {
+                parent.pass();
+            } else {
+                parent.fail();
+            }
+        }
     }
 
     /**

--- a/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/model/TestSuiteRun.java
+++ b/org.metaborg.spt.testrunner.eclipse/src/main/java/org/metaborg/spt/testrunner/eclipse/model/TestSuiteRun.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.vfs2.FileObject;
+import org.metaborg.core.project.IProject;
+import org.metaborg.spt.core.extract.ISpoofaxTestCaseExtractionResult;
 
 /**
  * Represents running all the tests in a test suite.
@@ -14,24 +16,35 @@ public class TestSuiteRun {
     public final String name;
     public final List<TestCaseRun> tests = new ArrayList<>();
     public final FileObject file;
+    public final IProject project;
+    public final ISpoofaxTestCaseExtractionResult ext;
 
     private int numFailed = 0;
+    private int numPassed = 0;
 
     /**
      * Create a TestSuiteRun to represent the running of all tests in the test suite with the given name.
      * 
+     * @param ext
+     *            the result of extracting this test suite (a failed extraction is ok).
+     * @param project
+     *            the project containing this test suite.
      * @param file
      *            the file containing the module (required so double clicking opens the module)
      * @param name
      *            the name of the test suite.
      */
-    public TestSuiteRun(FileObject file, String name) {
-        this(file, null, name);
+    public TestSuiteRun(ISpoofaxTestCaseExtractionResult ext, IProject project, FileObject file, String name) {
+        this(ext, project, file, null, name);
     }
 
     /**
      * Create a TestSuiteRun to represent the running of all tests in the test suite with the given name.
      * 
+     * @param ext
+     *            the result of extracting this test suite (a failed extraction is ok).
+     * @param project
+     *            the project containing this test suite.
      * @param file
      *            the file containing the module (required so double clicking opens the module)
      * @param parent
@@ -40,7 +53,10 @@ public class TestSuiteRun {
      * @param name
      *            the name of the test suite.
      */
-    public TestSuiteRun(FileObject file, MultiTestSuiteRun parent, String name) {
+    public TestSuiteRun(ISpoofaxTestCaseExtractionResult ext, IProject project, FileObject file,
+        MultiTestSuiteRun parent, String name) {
+        this.ext = ext;
+        this.project = project;
         this.file = file;
         this.parent = parent;
         this.name = name;
@@ -54,12 +70,29 @@ public class TestSuiteRun {
     }
 
     /**
+     * The number of successfully completed test case runs (so far) in this test suite.
+     */
+    public int numPassed() {
+        return numPassed;
+    }
+
+    /**
      * Called by our kids to notify us that they failed.
      */
     protected void fail() {
         numFailed++;
         if(parent != null) {
             parent.fail();
+        }
+    }
+
+    /**
+     * Called by our kids to notify us that they passed.
+     */
+    protected void pass() {
+        numPassed++;
+        if(parent != null) {
+            parent.pass();
         }
     }
 


### PR DESCRIPTION
It can now be invoked 3 different ways:
1. through the project context menu (right click) in the `Spoofax (meta)` submenu.
   In this case it runs all SPT files under the project you right clicked.
2. through the `Spoofax (meta)` menu bar entry, then select `Run tests of SPT file`.
   In this case it will check if you currently have an SPT file open, and if so, run it.
3. through the `Spoofax (meta)` menu bar entry, then select `Run all selected tests`.
   In this case it will check what you selected.
   If you selected any SPT files, directories, or projects, it will scan all of the selections and run all of the SPT files it found within those selections.

The testrunner UI has been updated.
Here's a quick documentation on how it works.

It will start displaying any test suites and test cases within those test suites as soon as it discovers them.
Then, after they are all loaded, they will be run one by one, and the progress bar at the top will increase.
As long as the progress bar remains green, no tests failed yet.
As soon as a test fails, the progress bar will turn red to indicate so.

The numbers next to the progress bar also indicate the progress.
For example, `5 / 7` means 5 tests passed already out of a total of 7 tests.
This can mean that either 2 tests failed, or some tests have not been executed yet.
Which case applies can be determined by looking at the progress bar.

Any selections that don't contain any SPT files are ignored.
Any SPT files that fail to extract will be included in the list on the bottom left side, along with the test suites that did manage to get extracted.
The ones that did not extract properly will be displayed in red, as opposed to the default black color for test suites.
By selecting a red test suite, the extraction errors will be displayed in the console on the bottom right.
Any test suite can be double clicked to open the corresponding file in Eclipse.
Test suites that got extracted succesfully can be expanded if they contained any test cases.
This will show all the test cases of that suite as child elements of the test suite in the bottom left view.

Test cases are displayed in the default black color if they have not been executed yet.
Test cases that have finished will have their duration appended to their name.
Failed test cases are displayed in red, and passing test cases are displayed in green.
A red test case can be selected, doing so will show the messages about the test failure,
including the exceptions that caused them (e.g. a `StrategoRuntimeException` with stacktrace) in the console on the bottom right.
Double clicking a test case will open the corresponding SPT file and jump to the location of the test case.

When a test case fails, the test suite that contained the failing test case will be appended with the number of failed tests in that test suite so far.