### PR TITLE
Do not allow messages of the expected severity outside of the test region

### DIFF
--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/AnalyzeExpectationEvaluator.java
@@ -87,14 +87,23 @@ public class AnalyzeExpectationEvaluator implements ISpoofaxExpectationEvaluator
         int expectedNumMessages, Iterable<Integer> selectionRefs, Operation operation, @Nullable String content,
         Collection<IMessage> messages) {
         // collect the messages of the given severity and proper location
+        boolean hiddenMessages = false;
         List<IMessage> interestingMessages = Lists.newLinkedList();
         for(IMessage message : analysisMessages) {
-            if(severity == message.severity()
-                && (message.region() == null || test.getFragment().getRegion().contains(message.region()))) {
-                interestingMessages.add(message);
+            if(severity == message.severity()) {
+                if(message.region() == null || test.getFragment().getRegion().contains(message.region())) {
+                    interestingMessages.add(message);
+                } else {
+                    hiddenMessages = true;
+                }
             }
         }
 
+        if(hiddenMessages) {
+            messages.add(MessageFactory.newAnalysisError(test.getResource(), test.getDescriptionRegion(),
+                "Found unexpected matching messages outside the test region", null));
+        }
+        
         // check the number of messages
         final boolean numOk;
         switch(operation) {

--- a/org.metaborg.spt.test/analyze/analyze-fixture-errors.spt
+++ b/org.metaborg.spt.test/analyze/analyze-fixture-errors.spt
@@ -1,0 +1,42 @@
+module analyze-fixture-errors
+
+language SPT-Interactive
+
+fixture [[[
+  module analyze-fixture-errors
+  language MiniSQL
+
+  fixture [[
+    CREATE TABLE T (i int);
+    CREATE TABLE T (i int);
+
+    [[...]]
+  ]]
+  
+  [[[...]]]
+]]]
+
+
+test errors in fixture and fragment, expect only fragment errors (negative) [[[
+  test errors in fixture and fragment, expect only fragment errors (negative) [[
+    CREATE TABLE T (i int);
+  ]] 1 errors
+]]] analysis fails
+
+test errors in fixture and fragment, expect all errors (negative) [[[
+  test errors in fixture and fragment, expect all errors (negative) [[
+    CREATE TABLE T (i int);
+  ]] 3 errors
+]]] analysis fails
+
+test errors in fixture ignored with warnings (positive) [[[
+  test errors in fixture ignored with warnings (positive) [[
+    CREATE TABLE mytable (i int);
+  ]] 1 warning
+]]] analysis succeeds
+
+test errors in fixture ignored with notes (positive) [[[
+  test errors in fixture ignored with notes (positive) [[
+    CREATE TABLE Note (i int);
+  ]] 1 note
+]]] analysis succeeds

--- a/org.metaborg.spt.test/analyze/analyze-fixture-notes.spt
+++ b/org.metaborg.spt.test/analyze/analyze-fixture-notes.spt
@@ -1,0 +1,44 @@
+module analyze-fixture-errors
+
+language SPT-Interactive
+
+fixture [[[
+  module analyze-fixture-errors
+  language MiniSQL
+
+  fixture [[
+    // there will be a note on the name
+    CREATE TABLE Note (i int);
+
+    [[...]]
+  ]]
+  
+  [[[...]]]
+]]]
+
+
+test notes in fixture and fragment, expect only fragment notes (negative) [[[
+  test notes in fixture and fragment, expect only fragment notes (negative) [[
+    CREATE TABLE AnotherNote (i int);
+  ]] 1 notes
+]]] analysis fails
+
+test notes in fixture and fragment, expect all notes (negative) [[[
+  test notes in fixture and fragment, expect all notes (negative) [[
+    CREATE TABLE AnotherNote (i int);
+  ]] 2 notes
+]]] analysis fails
+
+
+test notes in fixture ignored with errors (positive) [[[
+  test notes in fixture ignored with errors (positive) [[
+    CREATE TABLE T (i int);
+    CREATE TABLE T (i int);
+  ]] 2 errors
+]]] analysis succeeds
+
+test notes in fixture ignored with warnings (positive) [[[
+  test notes in fixture ignored with warnings (positive) [[
+    CREATE TABLE mytable (i int);
+  ]] 1 warning
+]]] analysis succeeds

--- a/org.metaborg.spt.test/analyze/analyze-fixture-warnings.spt
+++ b/org.metaborg.spt.test/analyze/analyze-fixture-warnings.spt
@@ -1,0 +1,44 @@
+module analyze-fixture-errors
+
+language SPT-Interactive
+
+fixture [[[
+  module analyze-fixture-errors
+  language MiniSQL
+
+  fixture [[
+    // there will be a warning on the name
+    CREATE TABLE mytable (i int);
+
+    [[...]]
+  ]]
+  
+  [[[...]]]
+]]]
+
+
+test warnings in fixture and fragment, expect only fragment warnings (negative) [[[
+  test warnings in fixture and fragment, expect only fragment warnings (negative) [[
+    CREATE TABLE myothertable (i int);
+  ]] 1 warnings
+]]] analysis fails
+
+test warnings in fixture and fragment, expect all warnings (negative) [[[
+  test warnings in fixture and fragment, expect all warnings (negative) [[
+    CREATE TABLE myothertable (i int);
+  ]] 2 warnings
+]]] analysis fails
+
+
+test warnings in fixture ignored with errors (positive) [[[
+  test warnings in fixture ignored with errors (positive) [[
+    CREATE TABLE T (i int);
+    CREATE TABLE T (i int);
+  ]] 2 errors
+]]] analysis succeeds
+
+test warnings in fixture ignored with notes (positive) [[[
+  test warnings in fixture ignored with notes (positive) [[
+    CREATE TABLE Note (i int);
+  ]] 1 note
+]]] analysis succeeds

--- a/org.metaborg.spt.test/analyze/analyze-messages.spt
+++ b/org.metaborg.spt.test/analyze/analyze-messages.spt
@@ -6,65 +6,41 @@ fixture [[[
   module analyze-messages
   language MiniSQL
 
-  fixture [[
-    // there will be a note on the name
-    CREATE TABLE Note (i int);
-    // there will be a warning on the name
-    CREATE TABLE mytable (i int);
-    CREATE TABLE T (i int);
-
-    [[...]]
-  ]]
-  
   [[[...]]]
 ]]]
 
-test error only in fragment (positive) [[[
+test errors only in fragment (positive) [[[
   test error only in fragment (positive) [[
-    CREATE TABLE T (i int);
-  ]] 1 error
+    CREATE TABLE U (i int);
+    CREATE TABLE U (i int);
+  ]] 2 error
 ]]] analysis succeeds
 
-test error only in fragment (negative) [[[
-  test error only in fragment (negative) [[
-    CREATE TABLE T (i int);
-  ]] 2 errors
-]]] analysis fails
-
-
-test warning only in fragment (positive) [[[
+test warnings only in fragment (positive) [[[
   test warning only in fragment (positive) [[
-    CREATE TABLE mytable (i int);
+    CREATE TABLE mytable2 (i int);
   ]] 1 warning
 ]]] analysis succeeds
 
-test warning only in fragment (negative) [[[
-  test warning only in fragment (negative) [[
-    CREATE TABLE mytable (i int);
-  ]] 2 warnings
-]]] analysis fails
-
-test note only in fragment (positive) [[[
+test notes only in fragment (positive) [[[
   test note only in fragment (positive) [[
     CREATE TABLE Note (i int);
   ]] 1 note
 ]]] analysis succeeds
 
-test note only in fragment (negative) [[[
-  test note only in fragment (negative) [[
-    CREATE TABLE Note (i int);
-  ]] 2 notes
-]]] analysis fails
-
 test warnings and notes allowed with error (positive) [[[
   test warnings and notes allowed with error (positive) [[
+    CREATE TABLE U (i int);
+    CREATE TABLE U (i int);
     CREATE TABLE Note(i int);
     CREATE TABLE woop(i int);
-  ]] 1 error
+  ]] 2 errors
 ]]] analysis succeeds
 
 test errors and notes allowed with warning (positive) [[[
   test errors and notes allowed with warning (positive) [[
+    CREATE TABLE U (i int);
+    CREATE TABLE U (i int);
     CREATE TABLE Note(i int);
     CREATE TABLE woop(i int);
   ]] 1 warning
@@ -72,6 +48,8 @@ test errors and notes allowed with warning (positive) [[[
 
 test errors and warnings allowed with notes (positive) [[[
   test errors and warnings allowed with notes (positive) [[
+    CREATE TABLE U (i int);
+    CREATE TABLE U (i int);
     CREATE TABLE Note(i int);
     CREATE TABLE woop(i int);
   ]] 1 note
@@ -143,10 +121,11 @@ test note location ignores warning (negative) [[[
 test error with operators (positive) [[[
   test error with operators (positive) [[
     CREATE TABLE T ();
+    CREATE TABLE T ();
   ]] 
-  <= 1 errors
-  = 1 error
-  >= 1 error
+  <= 2 errors
+  = 2 error
+  >= 2 error
 ]]] analysis succeeds
 
 test error with > (positive) [[[
@@ -237,11 +216,13 @@ test use of analysis succeeds with warnings allowed (positive) [[[
 test use of analysis succeeds with errors (negative) [[[
   test use of analysis succeeds (positive) [[
     CREATE TABLE T();
+    CREATE TABLE T();
   ]] analysis succeeds
 ]]] analysis fails
 
 test use of analysis fails (positive) [[[
   test use of analysis succeeds (positive) [[
+    CREATE TABLE T();
     CREATE TABLE T();
   ]] analysis succeeds
 ]]] analysis fails
@@ -260,6 +241,7 @@ test use of analysis fails with only warnings should fail (negative) [[[
 
 test use of analysis fails (positive) [[[
   test use of analysis fails (positive) [[
+    CREATE TABLE T();
     CREATE TABLE T();
   ]] analysis fails
 ]]] analysis succeeds


### PR DESCRIPTION
This PR disallows messages to appear outside the test region. The issue I'm trying to solve is the fact that error locations can be unpredicatable (e.g. in the case of constraints and inference). So, sometimes there is an error in the fragment, but the message will be put on an element in the fixture. Testing for `0 errors` should certainly not succeed in this case.

I've currently implemented it as liberal as possible. Only if messages would match inside the fragment (i.e. have the expected severity), do they make the test fail.

I think this is safer semantics than we currently have. It may introduce some false negatives, but at least we do not get false positives.