### PR TITLE
Fix quote escaping in expectation strings terms

### DIFF
--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTUtil.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/SPTUtil.java
@@ -292,7 +292,7 @@ public class SPTUtil {
                 return b;
             case STRING_CONS:
                 // String("some string")
-                b.append(Term.asJavaString(match.getSubterm(0)));
+                b.append("\"" + Term.asJavaString(match.getSubterm(0)).replace("\\", "\\\\").replace("\"", "\\\"") + "\"");
                 return b;
             case WLD_CONS:
                 b.append('_');

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseBuilder.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseBuilder.java
@@ -19,8 +19,12 @@ import org.metaborg.spt.core.SPTUtil;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 import org.spoofax.interpreter.core.Tools;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoString;
 import org.spoofax.interpreter.terms.IStrategoTerm;
-
+import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.terms.StrategoString;
+import org.spoofax.terms.TermFactory;
 import com.google.inject.Inject;
 
 public class SpoofaxTestCaseBuilder implements ISpoofaxTestCaseBuilder {
@@ -84,7 +88,7 @@ public class SpoofaxTestCaseBuilder implements ISpoofaxTestCaseBuilder {
             // if(trace.location(expectation) == null) {
             // logger.warn("No origin information on test expectation {}", expectation);
             // }
-            expectationTerms.add(expectation);
+        	expectationTerms.add(unescapeExpectation(expectation));
         }
 
         // setup the fragment builder
@@ -92,6 +96,45 @@ public class SpoofaxTestCaseBuilder implements ISpoofaxTestCaseBuilder {
         fragmentBuilder.withFragment(fragmentTerm);
 
         return this;
+    }
+    
+    /**
+     * Unescape string terms of expectations by replacing \" with ".
+     */
+    private IStrategoTerm unescapeExpectation(IStrategoTerm expectation) {
+    	ITermFactory factory = new TermFactory();
+    	
+    	switch(expectation.getTermType()) {
+	        case IStrategoTerm.APPL:
+	        	IStrategoAppl appl = (IStrategoAppl) expectation;
+	        	IStrategoTerm[] kids;
+	        	
+	        	if ("String".equals(appl.getConstructor().getName()) ) {
+	        		StrategoString escapedString = (StrategoString) appl.getSubterm(0);
+	        		IStrategoString unescapedString = factory.makeString(escapedString.stringValue().replace("\\\"", "\""));
+	        		
+	        		kids = new IStrategoTerm[] {unescapedString};
+	        	} else {
+	        		kids = unescapeExpectationKids(expectation);
+	        	}
+		        
+	        	return factory.makeAppl(appl.getConstructor(), kids, expectation.getAnnotations());
+	        case IStrategoTerm.LIST:
+	        	return factory.makeList(unescapeExpectationKids(expectation), expectation.getAnnotations());
+	        case IStrategoTerm.TUPLE:
+	        	return factory.makeTuple(unescapeExpectationKids(expectation), expectation.getAnnotations());
+	        default:
+	            return expectation;
+	    }
+    }
+    
+    private IStrategoTerm[] unescapeExpectationKids(IStrategoTerm expectation) {
+    	IStrategoTerm[] kids = new IStrategoTerm[expectation.getSubtermCount()];
+    	
+    	for (int i = 0; i < expectation.getSubtermCount(); i++)
+    		kids[i] = unescapeExpectation(expectation.getSubterm(i));
+    	
+    	return kids;
     }
 
     @Override public ITestCase build() {

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseBuilder.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/extract/SpoofaxTestCaseBuilder.java
@@ -23,6 +23,7 @@ import org.spoofax.interpreter.terms.IStrategoAppl;
 import org.spoofax.interpreter.terms.IStrategoString;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.terms.StrategoString;
 import org.spoofax.terms.TermFactory;
 import com.google.inject.Inject;
@@ -104,6 +105,8 @@ public class SpoofaxTestCaseBuilder implements ISpoofaxTestCaseBuilder {
     private IStrategoTerm unescapeExpectation(IStrategoTerm expectation) {
     	ITermFactory factory = new TermFactory();
     	
+    	IStrategoTerm unescapedExpectation;
+    	
     	switch(expectation.getTermType()) {
 	        case IStrategoTerm.APPL:
 	        	IStrategoAppl appl = (IStrategoAppl) expectation;
@@ -118,14 +121,20 @@ public class SpoofaxTestCaseBuilder implements ISpoofaxTestCaseBuilder {
 	        		kids = unescapeExpectationKids(expectation);
 	        	}
 		        
-	        	return factory.makeAppl(appl.getConstructor(), kids, expectation.getAnnotations());
+	        	unescapedExpectation = factory.makeAppl(appl.getConstructor(), kids, expectation.getAnnotations()); break;
 	        case IStrategoTerm.LIST:
-	        	return factory.makeList(unescapeExpectationKids(expectation), expectation.getAnnotations());
+	        	unescapedExpectation = factory.makeList(unescapeExpectationKids(expectation), expectation.getAnnotations()); break;
 	        case IStrategoTerm.TUPLE:
-	        	return factory.makeTuple(unescapeExpectationKids(expectation), expectation.getAnnotations());
+	        	unescapedExpectation = factory.makeTuple(unescapeExpectationKids(expectation), expectation.getAnnotations()); break;
 	        default:
 	            return expectation;
 	    }
+    	
+    	ImploderAttachment attachment = expectation.getAttachment(ImploderAttachment.TYPE);
+    	
+    	unescapedExpectation.putAttachment(attachment);
+    	
+    	return unescapedExpectation;
     }
     
     private IStrategoTerm[] unescapeExpectationKids(IStrategoTerm expectation) {


### PR DESCRIPTION
We had the following problems with escaping in string terms of expectations:

1. Double quotations (`"`) in strings of expectation terms require escaping using backslashes, but are not unescaped when comparing with actual parse results. This makes tests with double quotations in strings fail.
2. Formatting expectation terms as strings is different than default ATerms (`"` and `\` are not escaped), which is confusing when a test fails and the actual and expected terms are reported.

Example:

![image](https://user-images.githubusercontent.com/2210857/40879082-22c5ce26-669b-11e8-8aec-9eb04c96add3.png)

This PR fixes these issues by unescaping the double quotations in the expectation terms and by adding the escaping to the SPT term formatter.
