### PR TITLE
Support multiple name resolution targets

### DIFF
--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ResolveExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ResolveExpectationEvaluator.java
@@ -128,7 +128,8 @@ public class ResolveExpectationEvaluator implements ISpoofaxExpectationEvaluator
                 // check if it resolved to the proper term
                 boolean found = false;
                 ISourceRegion selection = selections.get(num2);
-                for(ISourceLocation loc : r.targets) {
+                for(Resolution.Target target : r.targets) {
+                    ISourceLocation loc = target.location;
                     if(loc.region().startOffset() == selection.startOffset() // match start offset
                         && loc.region().endOffset() == selection.endOffset() // match end offset
                         && loc.resource() != null // match resource
@@ -139,7 +140,7 @@ public class ResolveExpectationEvaluator implements ISpoofaxExpectationEvaluator
                 }
                 success = found;
                 if(!found) {
-                    ISourceLocation target = r.targets.iterator().next();
+                    ISourceLocation target = r.targets.iterator().next().location;
                     ISourceRegion targetRegion = target.region();
                     final String msg;
                     if(targetRegion.startOffset() != selection.startOffset()

--- a/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ResolveExpectationEvaluator.java
+++ b/org.metaborg.spt.core/src/main/java/org/metaborg/spt/core/run/expectations/ResolveExpectationEvaluator.java
@@ -10,6 +10,7 @@ import org.metaborg.core.messages.MessageFactory;
 import org.metaborg.core.source.ISourceLocation;
 import org.metaborg.core.source.ISourceRegion;
 import org.metaborg.core.tracing.Resolution;
+import org.metaborg.core.tracing.ResolutionTarget;
 import org.metaborg.mbt.core.model.IFragment;
 import org.metaborg.mbt.core.model.ITestCase;
 import org.metaborg.mbt.core.model.TestPhase;
@@ -128,7 +129,7 @@ public class ResolveExpectationEvaluator implements ISpoofaxExpectationEvaluator
                 // check if it resolved to the proper term
                 boolean found = false;
                 ISourceRegion selection = selections.get(num2);
-                for(Resolution.Target target : r.targets) {
+                for(ResolutionTarget target : r.targets) {
                     ISourceLocation loc = target.location;
                     if(loc.region().startOffset() == selection.startOffset() // match start offset
                         && loc.region().endOffset() == selection.endOffset() // match end offset


### PR DESCRIPTION
Propagates changes to `Resolution`.

PR group:
metaborg/spt#23
metaborg/spoofax#38
metaborg/spoofax-eclipse#13
metaborg/nabl#14
metaborg/spoofax-intellij#29

<img width="240" alt="multi-resolution" src="https://user-images.githubusercontent.com/1237863/42413822-ccb3d196-8228-11e8-9372-b318e9d6fc0c.png">
