### PR TITLE
Use Java version of sdf2table to enable Unicode support

### DIFF
--- a/org.metaborg.meta.lang.spt.interactive/metaborg.yaml
+++ b/org.metaborg.meta.lang.spt.interactive/metaborg.yaml
@@ -17,6 +17,8 @@ pardonedLanguages:
 - Stratego-Sugar
 - SDF
 language:
+  sdf:
+    sdf2table: java
   stratego:
     format: ctree
     args:

--- a/org.metaborg.meta.lang.spt/metaborg.yaml
+++ b/org.metaborg.meta.lang.spt/metaborg.yaml
@@ -17,13 +17,15 @@ exports:
   directory: src-gen
 - language: TemplateLang
   directory: syntax
-- language: SDF
+- language: ATerm
   directory: src-gen/syntax
 - language: Stratego-Sugar
   directory: trans
 - language: Stratego-Sugar
   directory: src-gen
 language:
+  sdf:
+    sdf2table: java
   stratego:
     format: ctree
     args:


### PR DESCRIPTION
Related to metaborg/jsglr#72 and metaborg/sdf#38. Should be merged before or together with the other Unicode PRs to avoid breaking the build, as I added some Unicode to SDF3 SPT tests.

To allow `spt.interactive` to build upon `spt`, the `interactive` project also required `sdf2table: java`, together with `ATerm` exports from `spt/src-gen/syntax` (since the normalized grammar is stored in ATerm format).

I also removed the export `language: SDF` with `directory: src-gen/syntax`, since no SDF2 code is generated anymore (as was done by `sdf2table: c`).