### PR TITLE
Fix imploder attachments on sublists

### DIFF
--- a/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/MessageUtil.java
+++ b/org.metaborg.mbt.core/src/main/java/org/metaborg/mbt/core/model/expectations/MessageUtil.java
@@ -95,12 +95,8 @@ public class MessageUtil {
                 || region.startOffset() > bounds.endOffset()) {
                 logger.debug("Propagating '{}' at the default region due to bounds {}, not its own region {}",
                     message.message(), bounds, region);
-                messages
-                    .add(
-                        setMessage(setRegion(message, defaultRegion),
-                            message.message() + String.format(" (Relocated this message. Original location: (%s, %s))",
-                                region == null ? null : region.startOffset(),
-                                region == null ? null : region.endOffset())));
+                messages.add(setMessage(setRegion(message, defaultRegion),
+                    message.message() + " (Relocated this message. Original location: (" + region + "))"));
             } else if(region.startOffset() < bounds.startOffset() && region.endOffset() > bounds.endOffset()) {
                 logger.debug("Propagating '{}' and cutting of the beginning and end offsets", message.message());
                 messages.add(setRegion(message, new SourceRegion(bounds.startOffset(), bounds.endOffset())));


### PR DESCRIPTION
As discussed on Zoom and Slack :slightly_smiling_face: The full build passes :smile: 

The actual fix is around lines 200-230 in the `SpoofaxOriginFragmentParser`. The updating of the imploder attachment has been extracted to a separate method, which is now also called on all the sub-lists of a list term.

Along the way, I made two other changes:
- In `MessageUtil`, I wanted to print the line and column of the original message location, so initially I added four extra lines for the `{start,end}{Row,Column}()` methods, but then I realized that all fields are already printed in `SourceRegion.toString()`, so I used that instead.
- In `SpoofaxOriginFragmentParser$MappingTokenizer.toString(int startOffset, int endOffset)`, I fixed an off-by-one error caused by mistaking inclusive for exclusive end offsets.