### PR TITLE
Remove ECJ dependency

### DIFF
--- a/org.metaborg.meta.lang.spt/build.gradle.kts
+++ b/org.metaborg.meta.lang.spt/build.gradle.kts
@@ -20,6 +20,12 @@ dependencies {
   sourceLanguage(compositeBuild("meta.lib.spoofax"))
 }
 
+metaborg { // Do not create Java publication; this project is already published as a Spoofax 2 language.
+  javaCreatePublication = false
+  javaCreateSourcesJar = false
+  javaCreateJavadocJar = false
+}
+
 ecj {
   toolVersion = "3.21.0"
 }

--- a/org.metaborg.meta.lang.spt/build.gradle.kts
+++ b/org.metaborg.meta.lang.spt/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("org.metaborg.gradle.config.java-library")
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
 }
 
@@ -24,11 +23,4 @@ metaborg { // Do not create Java publication; this project is already published 
   javaCreatePublication = false
   javaCreateSourcesJar = false
   javaCreateJavadocJar = false
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }

--- a/org.metaborg.meta.lang.spt/syntax/spt/ATerm.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/ATerm.sdf3
@@ -9,7 +9,7 @@ TermAnno.Anno = <<PreTerm>{<{PreTerm ", "}*>}>
 // Lists conflict with fragment markers, so they can't be ATerm in our grammar
 TermList.List = <[<{Term ", "}*>]>
 
-Term.Appl = <<ID>(<{MidTerm ", "}*>)>
+Term.Appl = <<CONS>(<{MidTerm ", "}*>)>
 Term.Tuple = <(<{MidTerm ", "}*>)>
 Term.Int = <<INT>>
 Term.String = <<ASTRING>>

--- a/org.metaborg.meta.lang.spt/syntax/spt/Common.sdf3
+++ b/org.metaborg.meta.lang.spt/syntax/spt/Common.sdf3
@@ -7,6 +7,7 @@ lexical syntax
   MODULE-PATH    = {MODULE-ID "/"}+
   LANG           = [a-zA-Z] [a-zA-Z0-9\-\_]*
   SORT           = [a-zA-Z] [a-zA-Z0-9\-\_]*
+  CONS           = [a-zA-Z] [a-zA-Z0-9\-\_]*
   STRAT          = [a-zA-Z] [a-zA-Z0-9\-\_\']*
   INT            = "-"? [0-9]+
   STRING         = "\"" StringChar* "\""
@@ -33,6 +34,7 @@ lexical restrictions
   MODULE-ID     -/- [a-zA-Z0-9\-\_\']
   LANG          -/- [a-zA-Z0-9\-\_\']
   SORT          -/- [a-zA-Z0-9\-\_\']
+  CONS          -/- [a-zA-Z0-9\-\_\']
   STRAT         -/- [a-zA-Z0-9\-\_\']
   INT           -/- [0-9]
 


### PR DESCRIPTION
This PR removes the ECJ build dependency because [the plugin](https://github.com/TwoStone/gradle-eclipse-compiler-plugin) is severely out of date, deprecated, and not supported in recent Gradle versions.